### PR TITLE
Add support for ghc-9.0.1

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -13,3 +13,23 @@ source-repository-package
 
 tests: True
 test-show-details: direct
+
+allow-newer:
+  lens:template-haskell,
+  parallel:base,
+  hashable:base,
+  async:base,
+  quickcheck-instances:base,
+  time-compat:base,
+  these:base,
+  assoc:base,
+  cryptohash-sha1:base,
+  cryptohash-md5:base,
+  split:base,
+  constraints-extras:base,
+  constraints-extras:template-haskell,
+  dependent-sum:some,
+  hslogger:base,
+  entropy:Cabal,
+  lens:Cabal
+  

--- a/func-test/func-test.cabal
+++ b/func-test/func-test.cabal
@@ -6,7 +6,7 @@ build-type:          Simple
 test-suite func-test
   main-is:             FuncTest.hs
   type:                exitcode-stdio-1.0
-  build-depends:       base <4.15
+  build-depends:       base <4.16
                      , lsp-test
                      , lsp
                      , data-default

--- a/lsp-types/lsp-types.cabal
+++ b/lsp-types/lsp-types.cabal
@@ -67,7 +67,7 @@ library
                      , Language.LSP.Types.WorkspaceSymbol
  -- other-extensions:
   ghc-options:         -Wall
-  build-depends:       base >= 4.11 && < 4.15
+  build-depends:       base >= 4.11 && < 4.16
                      , aeson >=1.2.2.0
                      , binary
                      , bytestring

--- a/lsp.cabal
+++ b/lsp.cabal
@@ -31,7 +31,7 @@ library
                      , Language.LSP.Server.Control
                      , Language.LSP.Server.Processing
   ghc-options:         -Wall
-  build-depends:       base >= 4.11 && < 4.15
+  build-depends:       base >= 4.11 && < 4.16
                      , async
                      , aeson >=1.0.0.0
                      , attoparsec
@@ -68,7 +68,7 @@ executable lsp-demo-reactor-server
   default-language:    Haskell2010
   ghc-options:         -Wall -Wno-unticked-promoted-constructors
 
-  build-depends:       base >= 4.11 && < 4.15
+  build-depends:       base >= 4.11 && < 4.16
                      , aeson
                      , bytestring
                      , containers


### PR DESCRIPTION
* As first attempt, listing upstream packages needing patches in `allow-newer`
* This only can be built with cabal-3.4.0.0