### PR TITLE
Replace hand-written instances with deriving using appropriate options

### DIFF
--- a/lsp-types/src/Language/LSP/Types/Completion.hs
+++ b/lsp-types/src/Language/LSP/Types/Completion.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE TemplateHaskell            #-}
 module Language.LSP.Types.Completion where
 
-import           Control.Applicative
 import qualified Data.Aeson                    as A
 import           Data.Aeson.TH
 import           Data.Scientific                ( Scientific )
@@ -268,12 +267,7 @@ data CompletionDoc = CompletionDocString Text
                    | CompletionDocMarkup MarkupContent
   deriving (Show, Read, Eq)
 
-instance A.ToJSON CompletionDoc where
-  toJSON (CompletionDocString x) = A.toJSON x
-  toJSON (CompletionDocMarkup x) = A.toJSON x
-
-instance A.FromJSON CompletionDoc where
-  parseJSON x = CompletionDocString <$> A.parseJSON x <|> CompletionDocMarkup <$> A.parseJSON x
+deriveJSON lspOptionsUntagged ''CompletionDoc
 
 data InsertReplaceEdit =
   InsertReplaceEdit
@@ -287,12 +281,7 @@ deriveJSON lspOptions ''InsertReplaceEdit
 data CompletionEdit = CompletionEditText TextEdit | CompletionEditInsertReplace InsertReplaceEdit
   deriving (Read,Show,Eq)
 
-instance A.ToJSON CompletionEdit where
-  toJSON (CompletionEditText te)          = A.toJSON te
-  toJSON (CompletionEditInsertReplace ir) = A.toJSON ir
-
-instance A.FromJSON CompletionEdit where
-  parseJSON x = CompletionEditText <$> A.parseJSON x <|> CompletionEditInsertReplace <$> A.parseJSON x
+deriveJSON lspOptionsUntagged ''CompletionEdit
 
 data CompletionItem =
   CompletionItem

--- a/lsp-types/src/Language/LSP/Types/Hover.hs
+++ b/lsp-types/src/Language/LSP/Types/Hover.hs
@@ -2,8 +2,6 @@
 {-# LANGUAGE DuplicateRecordFields      #-}
 module Language.LSP.Types.Hover where
 
-import           Control.Applicative
-import           Data.Aeson
 import           Data.Aeson.TH
 import           Data.Text                      ( Text )
 
@@ -49,12 +47,7 @@ data MarkedString =
   | CodeString LanguageString
     deriving (Eq,Read,Show)
 
-instance ToJSON MarkedString where
-  toJSON (PlainString x) = toJSON x
-  toJSON (CodeString  x) = toJSON x
-instance FromJSON MarkedString where
-  parseJSON (String t) = pure $ PlainString t
-  parseJSON o            = CodeString <$> parseJSON o
+deriveJSON lspOptionsUntagged ''MarkedString
 
 -- -------------------------------------
 
@@ -63,15 +56,7 @@ data HoverContents =
   | HoverContents   MarkupContent
   deriving (Read,Show,Eq)
 
-instance ToJSON HoverContents where
-  toJSON (HoverContentsMS  x) = toJSON x
-  toJSON (HoverContents    x) = toJSON x
-instance FromJSON HoverContents where
-  parseJSON v@(String _) = HoverContentsMS <$> parseJSON v
-  parseJSON v@(Array _)  = HoverContentsMS <$> parseJSON v
-  parseJSON v@(Object _) = HoverContents   <$> parseJSON v
-                         <|> HoverContentsMS <$> parseJSON v
-  parseJSON _ = mempty
+deriveJSON lspOptionsUntagged ''HoverContents
 
 -- -------------------------------------
 

--- a/lsp-types/src/Language/LSP/Types/Progress.hs
+++ b/lsp-types/src/Language/LSP/Types/Progress.hs
@@ -6,7 +6,6 @@
 
 module Language.LSP.Types.Progress where
 
-import           Control.Applicative
 import           Control.Monad (unless)
 import qualified Data.Aeson as A
 import           Data.Aeson.TH
@@ -22,14 +21,7 @@ data ProgressToken
     | ProgressTextToken Text
     deriving (Show, Read, Eq, Ord)
 
-instance A.ToJSON ProgressToken where
-    toJSON (ProgressNumericToken i) = A.toJSON i
-    toJSON (ProgressTextToken t) = A.toJSON t
-
-instance A.FromJSON ProgressToken where
-    parseJSON (A.String t) = pure $ ProgressTextToken t
-    parseJSON (A.Number i) = ProgressNumericToken <$> A.parseJSON (A.Number i)
-    parseJSON v = fail $ "Invalid progress token: " ++ show v
+deriveJSON lspOptionsUntagged ''ProgressToken
 
 -- | Parameters for a $/progress notification.
 data ProgressParams t =
@@ -39,23 +31,6 @@ data ProgressParams t =
     } deriving (Show, Read, Eq, Functor)
 
 deriveJSON lspOptions ''ProgressParams
-
-data SomeProgressParams
-  = Begin WorkDoneProgressBeginParams
-  | Report WorkDoneProgressReportParams
-  | End WorkDoneProgressEndParams
-  deriving Eq
-
-instance A.FromJSON SomeProgressParams where
-  parseJSON x =
-       (Begin  <$> A.parseJSON x)
-   <|> (Report <$> A.parseJSON x)
-   <|> (End    <$> A.parseJSON x)
-
-instance A.ToJSON SomeProgressParams where
-  toJSON (Begin  x) = A.toJSON x
-  toJSON (Report x) = A.toJSON x
-  toJSON (End    x) = A.toJSON x
 
 -- | Parameters for 'WorkDoneProgressBeginNotification'.
 --
@@ -220,6 +195,14 @@ data WorkDoneProgressParams =
       _workDoneToken :: Maybe ProgressToken
     } deriving (Read,Show,Eq)
 deriveJSON lspOptions ''WorkDoneProgressParams
+
+data SomeProgressParams
+  = Begin WorkDoneProgressBeginParams
+  | Report WorkDoneProgressReportParams
+  | End WorkDoneProgressEndParams
+  deriving Eq
+
+deriveJSON lspOptionsUntagged ''SomeProgressParams
 
 data PartialResultParams =
   PartialResultParams

--- a/lsp-types/src/Language/LSP/Types/SignatureHelp.hs
+++ b/lsp-types/src/Language/LSP/Types/SignatureHelp.hs
@@ -81,12 +81,7 @@ deriveJSON lspOptions ''SignatureHelpRegistrationOptions
 data SignatureHelpDoc = SignatureHelpDocString Text | SignatureHelpDocMarkup MarkupContent
   deriving (Read,Show,Eq)
 
-instance ToJSON SignatureHelpDoc where
-  toJSON (SignatureHelpDocString t) = toJSON t
-  toJSON (SignatureHelpDocMarkup m) = toJSON m
-
-instance FromJSON SignatureHelpDoc where
-  parseJSON x = SignatureHelpDocString <$> parseJSON x <|> SignatureHelpDocMarkup <$> parseJSON x
+deriveJSON lspOptionsUntagged ''SignatureHelpDoc
 
 -- -------------------------------------
 

--- a/lsp-types/src/Language/LSP/Types/Utils.hs
+++ b/lsp-types/src/Language/LSP/Types/Utils.hs
@@ -8,6 +8,7 @@ module Language.LSP.Types.Utils
   , makeRegHelper
   , makeExtendingDatatype
   , lspOptions
+  , lspOptionsUntagged
   ) where
 
 import Control.Monad
@@ -115,4 +116,8 @@ lspOptions = defaultOptions { omitNothingFields = True, fieldLabelModifier = mod
   modifier "_xdata" = "data"
   modifier "_xtype" = "type"
   modifier xs = drop 1 xs
+
+-- | Standard options for use when generating JSON instances for an untagged union
+lspOptionsUntagged :: Options
+lspOptionsUntagged = lspOptions { sumEncoding = UntaggedValue }
 


### PR DESCRIPTION
I believe in all of these cases the encodings are non-overlapping, so
it's safe.

I'm not brave enough to actually try getting rid of `|?` yet, but this at least avoids pointless instance definitions where we *are* using a separate type.