### PR TITLE
Fix lsp-test example

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -35,10 +35,6 @@ jobs:
           ${{ runner.os }}-
 
     - name: Build
-      run: cabal build
+      run: cabal build all
     - name: Test
-      run: cabal test
-    - name: Func test
-      run: cabal test func-test
-    - name: Test lsp-test
-      run: cabal test lsp-test
+      run: cabal test all

--- a/example/Reactor.hs
+++ b/example/Reactor.hs
@@ -242,6 +242,14 @@ handle = mconcat
           range = J.Range pos pos
       responder (Right $ Just rsp)
 
+  , requestHandler J.STextDocumentDocumentSymbol $ \req responder -> do
+      liftIO $ debugM "reactor.handle" "Processing a textDocument/documentSymbol request"
+      let J.DocumentSymbolParams _ _ doc = req ^. J.params
+          loc = J.Location (doc ^. J.uri) (J.Range (J.Position 0 0) (J.Position 0 0))
+          sym = J.SymbolInformation "lsp-hello" J.SkFunction Nothing loc Nothing
+          rsp = J.InR (J.List [sym])
+      responder (Right rsp)
+
   , requestHandler J.STextDocumentCodeAction $ \req responder -> do
       liftIO $ debugM "reactor.handle" $ "Processing a textDocument/codeAction request"
       let params = req ^. J.params

--- a/lsp-test/example/Test.hs
+++ b/lsp-test/example/Test.hs
@@ -1,13 +1,14 @@
+{-# LANGUAGE OverloadedStrings #-}
 import Control.Applicative.Combinators
 import Control.Monad.IO.Class
 import Language.LSP.Test
 import Language.LSP.Types
 
-main = runSession "haskell-language-server" fullCaps "../test/data/" $ do
+main = runSession "lsp-demo-reactor-server" fullCaps "../test/data/" $ do
   doc <- openDoc "Rename.hs" "haskell"
   
   -- Use your favourite favourite combinators.
-  skipManyTill loggingNotification (count 2 publishDiagnosticsNotification)
+  skipManyTill loggingNotification (count 1 publishDiagnosticsNotification)
 
   -- Send requests and notifications and receive responses
   rsp <- request STextDocumentDocumentSymbol $

--- a/lsp-test/example/example.cabal
+++ b/lsp-test/example/example.cabal
@@ -9,3 +9,4 @@ test-suite tests
   build-depends: base
                , lsp-test
                , parser-combinators
+  build-tool-depends: lsp:lsp-demo-reactor-server


### PR DESCRIPTION
I noticed this was broken doing `cabal build all`.

- Fix compilation of the test.
- Depend on and use `lsp-demo-reactor-server` instead of HLS so it is
actually testable in isolation.
- Teach `lsp-demo-reactor-server` to respond to `TextDocumentSymbol`
(could have changed the example but this was easy enough).
- Ensure that the CI builds and tests it so we won't miss it in future.