### PR TITLE
Support change annotations

### DIFF
--- a/example/Reactor.hs
+++ b/example/Reactor.hs
@@ -227,10 +227,10 @@ handle = mconcat
           newName = params ^. J.newName
       vdoc <- getVersionedTextDoc (params ^. J.textDocument)
       -- Replace some text at the position with what the user entered
-      let edit = J.TextEdit (J.mkRange l c l (c + T.length newName)) newName
+      let edit = J.InL $ J.TextEdit (J.mkRange l c l (c + T.length newName)) newName
           tde = J.TextDocumentEdit vdoc (J.List [edit])
           -- "documentChanges" field is preferred over "changes"
-          rsp = J.WorkspaceEdit Nothing (Just (J.List [J.InL tde]))
+          rsp = J.WorkspaceEdit Nothing (Just (J.List [J.InL tde])) Nothing
       responder (Right rsp)
 
   , requestHandler J.STextDocumentHover $ \req responder -> do

--- a/lsp-test/src/Language/LSP/Test.hs
+++ b/lsp-test/src/Language/LSP/Test.hs
@@ -604,16 +604,16 @@ applyEdit doc edit = do
   let supportsDocChanges = fromMaybe False $ do
         let mWorkspace = caps ^. LSP.workspace
         C.WorkspaceClientCapabilities _ mEdit _ _ _ _ _ _ <- mWorkspace
-        C.WorkspaceEditClientCapabilities mDocChanges _ _ <- mEdit
+        C.WorkspaceEditClientCapabilities mDocChanges _ _ _ _ <- mEdit
         mDocChanges
 
   let wEdit = if supportsDocChanges
       then
-        let docEdit = TextDocumentEdit verDoc (List [edit])
-        in WorkspaceEdit Nothing (Just (List [InL docEdit]))
+        let docEdit = TextDocumentEdit verDoc (List [InL edit])
+        in WorkspaceEdit Nothing (Just (List [InL docEdit])) Nothing
       else
         let changes = HashMap.singleton (doc ^. uri) (List [edit])
-        in WorkspaceEdit (Just changes) Nothing
+        in WorkspaceEdit (Just changes) Nothing Nothing
 
   let req = RequestMessage "" (IdInt 0) SWorkspaceApplyEdit (ApplyWorkspaceEditParams Nothing wEdit)
   updateState (FromServerMess SWorkspaceApplyEdit req)
@@ -728,7 +728,7 @@ formatRange doc opts range = do
 
 applyTextEdits :: TextDocumentIdentifier -> List TextEdit -> Session ()
 applyTextEdits doc edits =
-  let wEdit = WorkspaceEdit (Just (HashMap.singleton (doc ^. uri) edits)) Nothing
+  let wEdit = WorkspaceEdit (Just (HashMap.singleton (doc ^. uri) edits)) Nothing Nothing
       -- Send a dummy message to updateState so it can do bookkeeping
       req = RequestMessage "" (IdInt 0) SWorkspaceApplyEdit (ApplyWorkspaceEditParams Nothing wEdit)
   in updateState (FromServerMess SWorkspaceApplyEdit req)

--- a/lsp-test/src/Language/LSP/Test/Files.hs
+++ b/lsp-test/src/Language/LSP/Test/Files.hs
@@ -84,7 +84,7 @@ mapUris f event =
 
           newDocChanges = fmap (fmap swapDocumentChangeUri) $ e ^. documentChanges
           newChanges = fmap (swapKeys f) $ e ^. changes
-       in WorkspaceEdit newChanges newDocChanges
+       in WorkspaceEdit newChanges newDocChanges Nothing
 
     swapKeys :: (Uri -> Uri) -> HM.HashMap Uri b -> HM.HashMap Uri b
     swapKeys f = HM.foldlWithKey' (\acc k v -> HM.insert (f k) v acc) HM.empty

--- a/lsp-test/test/DummyServer.hs
+++ b/lsp-test/test/DummyServer.hs
@@ -143,7 +143,7 @@ handlers =
             edit = List [TextEdit (mkRange 0 0 0 5) "howdy"]
             params =
               ApplyWorkspaceEditParams (Just "Howdy edit") $
-                WorkspaceEdit (Just (HM.singleton docUri edit)) Nothing
+                WorkspaceEdit (Just (HM.singleton docUri edit)) Nothing Nothing
         resp $ Right Null
         void $ sendRequest SWorkspaceApplyEdit params (const (pure ()))
      , requestHandler STextDocumentCodeAction $ \req resp -> do

--- a/lsp-test/test/DummyServer.hs
+++ b/lsp-test/test/DummyServer.hs
@@ -160,6 +160,7 @@ handlers =
                 Nothing
                 Nothing
                 (Just (Command "" "deleteThis" Nothing))
+                Nothing
         resp $ Right $ InR <$> codeActions
      , requestHandler STextDocumentCompletion $ \_req resp -> do
         let res = CompletionList True (List [item])

--- a/lsp-test/test/Test.hs
+++ b/lsp-test/test/Test.hs
@@ -368,4 +368,4 @@ docChangesCaps :: ClientCapabilities
 docChangesCaps = def { _workspace = Just workspaceCaps }
   where
     workspaceCaps = def { _workspaceEdit = Just editCaps }
-    editCaps = WorkspaceEditClientCapabilities (Just True) Nothing Nothing
+    editCaps = WorkspaceEditClientCapabilities (Just True) Nothing Nothing Nothing Nothing

--- a/lsp-types/src/Language/LSP/Types/Capabilities.hs
+++ b/lsp-types/src/Language/LSP/Types/Capabilities.hs
@@ -42,7 +42,9 @@ capsForVersion (LSPVersion maj min) = ClientCapabilities (Just w) (Just td) (Jus
           (Just (WorkspaceEditClientCapabilities
                   (Just True)
                   (since 3 13 resourceOperations)
-                  Nothing))
+                  Nothing
+                  (since 3 16 True)
+                  (since 3 16 (WorkspaceEditChangeAnnotationClientCapabilities (Just True)))))
           (Just (DidChangeConfigurationClientCapabilities dynamicReg))
           (Just (DidChangeWatchedFilesClientCapabilities dynamicReg))
           (Just symbolCapabilities)

--- a/lsp-types/src/Language/LSP/Types/Capabilities.hs
+++ b/lsp-types/src/Language/LSP/Types/Capabilities.hs
@@ -116,7 +116,7 @@ capsForVersion (LSPVersion maj min) = ClientCapabilities (Just w) (Just td) (Jus
           (Just (CodeLensClientCapabilities dynamicReg))
           (Just (DocumentLinkClientCapabilities dynamicReg (since 3 15 True)))
           (since 3 6 (DocumentColorClientCapabilities dynamicReg))
-          (Just (RenameClientCapabilities dynamicReg (since 3 12 True)))
+          (Just (RenameClientCapabilities dynamicReg (since 3 12 True) (since 3 16 PsIdentifier) (since 3 16 True)))
           (Just publishDiagnosticsCapabilities)
           (since 3 10 foldingRangeCapability)
           (since 3 5 (SelectionRangeClientCapabilities dynamicReg))

--- a/lsp-types/src/Language/LSP/Types/Capabilities.hs
+++ b/lsp-types/src/Language/LSP/Types/Capabilities.hs
@@ -194,6 +194,10 @@ capsForVersion (LSPVersion maj min) = ClientCapabilities (Just w) (Just td) (Jus
           dynamicReg
           (since 3 8 (CodeActionLiteralSupport caKs))
           (since 3 15 True)
+          (since 3 16 True)
+          (since 3 16 True)
+          (since 3 16 (CodeActionResolveClientCapabilities (List [])))
+          (since 3 16 True)
     caKs = CodeActionKindClientCapabilities
               (List [ CodeActionQuickFix
                     , CodeActionRefactor

--- a/lsp-types/src/Language/LSP/Types/Capabilities.hs
+++ b/lsp-types/src/Language/LSP/Types/Capabilities.hs
@@ -149,7 +149,7 @@ capsForVersion (LSPVersion maj min) = ClientCapabilities (Just w) (Just td) (Jus
       CompletionItemKindClientCapabilities (Just ciKs)
 
     completionItemTagsCapabilities =
-      CompletionItemTagsClientCapabilities (List [ CtDeprecated ])
+      CompletionItemTagsClientCapabilities (List [ CitDeprecated ])
 
     ciKs
       | maj >= 3 && min >= 4 = List (oldCiKs ++ newCiKs)

--- a/lsp-types/src/Language/LSP/Types/CodeAction.hs
+++ b/lsp-types/src/Language/LSP/Types/CodeAction.hs
@@ -116,6 +116,13 @@ data CodeActionLiteralSupport =
 
 deriveJSON lspOptions ''CodeActionLiteralSupport
 
+data CodeActionResolveClientCapabilities =
+  CodeActionResolveClientCapabilities
+    { _properties :: List Text -- ^ The properties that a client can resolve lazily.
+    } deriving (Show, Read, Eq)
+
+deriveJSON lspOptions ''CodeActionResolveClientCapabilities
+
 data CodeActionClientCapabilities = CodeActionClientCapabilities
   { -- | Whether code action supports dynamic registration.
     _dynamicRegistration :: Maybe Bool,
@@ -124,7 +131,30 @@ data CodeActionClientCapabilities = CodeActionClientCapabilities
     -- Since 3.8.0
     _codeActionLiteralSupport :: Maybe CodeActionLiteralSupport,
     -- | Whether code action supports the `isPreferred` property. Since LSP 3.15.0
-    _isPreferredSupport :: Maybe Bool
+    _isPreferredSupport :: Maybe Bool,
+    -- | Whether code action supports the `disabled` property.
+    --
+    -- @since 3.16.0
+    _disabledSupport :: Maybe Bool,
+    -- | Whether code action supports the `data` property which is
+    -- preserved between a `textDocument/codeAction` and a
+    -- `codeAction/resolve` request.
+    --
+    -- @since 3.16.0
+    _dataSupport :: Maybe Bool,
+    -- | Whether the client supports resolving additional code action
+    -- properties via a separate `codeAction/resolve` request.
+    --
+    -- @since 3.16.0
+    _resolveSupport :: Maybe CodeActionResolveClientCapabilities,
+    -- | Whether the client honors the change annotations in
+    -- text edits and resource operations returned via the
+    -- `CodeAction#edit` property by for example presenting
+    -- the workspace edit in the user interface and asking
+    -- for confirmation.
+    --
+    -- @since 3.16.0
+    _honorsChangeAnnotations :: Maybe Bool
   }
   deriving (Show, Read, Eq)
 
@@ -133,7 +163,7 @@ deriveJSON lspOptions ''CodeActionClientCapabilities
 -- -------------------------------------
 
 makeExtendingDatatype "CodeActionOptions" [''WorkDoneProgressOptions]
-  [("_codeActionKinds", [t| Maybe (List CodeActionKind) |])]
+  [("_codeActionKinds", [t| Maybe (List CodeActionKind) |]), ("_resolveProvider", [t| Maybe Bool |]) ]
 deriveJSON lspOptions ''CodeActionOptions
 
 makeExtendingDatatype "CodeActionRegistrationOptions"
@@ -205,7 +235,12 @@ data CodeAction =
     -- | A command this code action executes. If a code action
     -- provides an edit and a command, first the edit is
     -- executed and then the command.
-    _command :: Maybe Command
+    _command :: Maybe Command,
+    -- | A data entry field that is preserved on a code action between
+    -- a `textDocument/codeAction` and a `codeAction/resolve` request.
+    --
+    -- @since 3.16.0
+    _xdata :: Maybe Value
   }
   deriving (Read, Show, Eq)
 deriveJSON lspOptions ''CodeAction

--- a/lsp-types/src/Language/LSP/Types/Completion.hs
+++ b/lsp-types/src/Language/LSP/Types/Completion.hs
@@ -100,14 +100,16 @@ instance A.FromJSON CompletionItemKind where
 
 data CompletionItemTag
   -- | Render a completion as obsolete, usually using a strike-out.
-  = CtDeprecated
+  = CitDeprecated
+  | CitUnknown Scientific
   deriving (Eq, Ord, Show, Read)
 
 instance A.ToJSON CompletionItemTag where
-  toJSON CtDeprecated  = A.Number 1
+  toJSON CitDeprecated  = A.Number 1
+  toJSON (CitUnknown i) = A.Number i
 
 instance A.FromJSON CompletionItemTag where
-  parseJSON (A.Number 1) = pure CtDeprecated
+  parseJSON (A.Number 1) = pure CitDeprecated
   parseJSON _            = mempty
 
 data CompletionItemTagsClientCapabilities =

--- a/lsp-types/src/Language/LSP/Types/Lens.hs
+++ b/lsp-types/src/Language/LSP/Types/Lens.hs
@@ -139,6 +139,7 @@ makeFieldsNoPrefix ''DeclarationParams
 makeFieldsNoPrefix ''CodeActionKindClientCapabilities
 makeFieldsNoPrefix ''CodeActionLiteralSupport
 makeFieldsNoPrefix ''CodeActionClientCapabilities
+makeFieldsNoPrefix ''CodeActionResolveClientCapabilities
 makeFieldsNoPrefix ''CodeActionOptions
 makeFieldsNoPrefix ''CodeActionRegistrationOptions
 makeFieldsNoPrefix ''CodeActionContext

--- a/lsp-types/src/Language/LSP/Types/Lens.hs
+++ b/lsp-types/src/Language/LSP/Types/Lens.hs
@@ -243,6 +243,8 @@ makeFieldsNoPrefix ''DocumentFilter
 
 -- WorkspaceEdit
 makeFieldsNoPrefix ''TextEdit
+makeFieldsNoPrefix ''ChangeAnnotation
+makeFieldsNoPrefix ''AnnotatedTextEdit
 makeFieldsNoPrefix ''VersionedTextDocumentIdentifier
 makeFieldsNoPrefix ''TextDocumentEdit
 makeFieldsNoPrefix ''CreateFileOptions
@@ -253,6 +255,7 @@ makeFieldsNoPrefix ''DeleteFileOptions
 makeFieldsNoPrefix ''DeleteFile
 makeFieldsNoPrefix ''WorkspaceEdit
 makeFieldsNoPrefix ''WorkspaceEditClientCapabilities
+makeFieldsNoPrefix ''WorkspaceEditChangeAnnotationClientCapabilities
 
 -- Workspace Folders
 makeFieldsNoPrefix ''WorkspaceFolder

--- a/lsp-types/src/Language/LSP/Types/Rename.hs
+++ b/lsp-types/src/Language/LSP/Types/Rename.hs
@@ -3,13 +3,28 @@
 
 module Language.LSP.Types.Rename where
 
+import Data.Aeson
 import Data.Aeson.TH
 import Data.Text (Text)
+import Data.Scientific (Scientific)
 
 import Language.LSP.Types.Location
 import Language.LSP.Types.TextDocument
 import Language.LSP.Types.Progress
 import Language.LSP.Types.Utils
+
+data PrepareSupportDefaultBehavior =
+  PsIdentifier |
+  PsUnknown Scientific
+  deriving (Read, Show, Eq)
+
+instance ToJSON PrepareSupportDefaultBehavior where
+  toJSON PsIdentifier  = Number 1
+  toJSON (PsUnknown i) = Number i
+
+instance FromJSON PrepareSupportDefaultBehavior where
+  parseJSON (Number 1) = pure PsIdentifier
+  parseJSON _          = mempty
 
 data RenameClientCapabilities =
   RenameClientCapabilities
@@ -20,6 +35,21 @@ data RenameClientCapabilities =
       --
       -- Since LSP 3.12.0
     , _prepareSupport :: Maybe Bool
+      -- | Client supports the default behavior result
+      -- (`{ defaultBehavior: boolean }`).
+      --
+      -- The value indicates the default behavior used by the client.
+      --
+      -- @since 3.16.0
+    , prepareSupportDefaultBehavior :: Maybe PrepareSupportDefaultBehavior
+      -- | Whether the client honors the change annotations in
+      -- text edits and resource operations returned via the
+      -- rename request's workspace edit by for example presenting
+      -- the workspace edit in the user interface and asking
+      -- for confirmation.
+      --
+      -- @since 3.16.0
+    , honorsChangeAnnotations :: Maybe Bool
     } deriving (Show, Read, Eq)
 
 deriveJSON lspOptions ''RenameClientCapabilities

--- a/src/Language/LSP/Server/Processing.hs
+++ b/src/Language/LSP/Server/Processing.hs
@@ -210,9 +210,9 @@ inferServerCapabilities clientCaps o h =
 
     codeActionProvider
       | clientSupportsCodeActionKinds
-      , supported_b STextDocumentCodeAction = Just $
-          maybe (InL True) (InR . CodeActionOptions Nothing . Just . List)
-                (codeActionKinds o)
+      , supported_b STextDocumentCodeAction = Just $ case codeActionKinds o of
+          Just ks -> InR $ CodeActionOptions Nothing (Just (List ks)) (supported SCodeLensResolve)
+          Nothing -> InL True
       | supported_b STextDocumentCodeAction = Just (InL True)
       | otherwise = Just (InL False)
 


### PR DESCRIPTION
Added some more missing capabilities while I was at it.

This one is a pain because the type of the edits in `WorkspaceEdit` changes. This has two main annoying factors:
- Lots of extra `InL`s and `InR`s. This is probably a good candidate for not using `|?`, but I wasn't sure.
- Annoyingly we can't easily access the fields that both `TextEdit` and `AnnotatedTextEdit` have in common, i.e. we can't just do `^. range` on `TextEdit |? AnnotatedTextEdit` even though both have `range`.

I'm tempted to resolve these by making an type (`AnEdit`?) for the union and giving it lenses that "do the right thing". That would avoid some of the annoying helper function proliferation.