### PR TITLE
Add support for ghc 9.0.1

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: haskell/actions/setup@v1
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: '3.2'
+        cabal-version: '3.4'
 
     - name: Cache
       uses: actions/cache@v1

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -34,6 +34,8 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-
 
+    - name: Cabal update
+      run: cabal update
     - name: Build
       run: cabal build all
     - name: Test

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['8.10.4', '8.8.3', '8.6.5', '8.4.4']
+        ghc: ['9.0.1', '8.10.4', '8.8.3', '8.6.5', '8.4.4']
         os: [ubuntu-latest, macOS-latest, windows-latest]
         exclude:
           - os: windows-latest

--- a/cabal.project
+++ b/cabal.project
@@ -18,22 +18,10 @@ max-backjumps: 10000
 
 allow-newer:
   lens:template-haskell,
-  parallel:base,
-  hashable:base,
-  async:base,
-  quickcheck-instances:base,
-  time-compat:base,
-  these:base,
-  assoc:base,
   cryptohash-sha1:base,
   cryptohash-md5:base,
-  split:base,
-  constraints-extras:base,
-  constraints-extras:template-haskell,
-  dependent-sum:some,
   hslogger:base,
   entropy:Cabal,
-  lens:Cabal
 
 -- Required for ghc-9.0.1 support
 source-repository-package

--- a/cabal.project
+++ b/cabal.project
@@ -35,3 +35,16 @@ allow-newer:
   entropy:Cabal,
   lens:Cabal
 
+-- Required for ghc-9.0.1 support
+source-repository-package
+  type: git
+  location: https://github.com/anka-213/th-extras
+  tag: 57a97b4df128eb7b360e8ab9c5759392de8d1659
+-- https://github.com/mokus0/th-extras/pull/8
+
+source-repository-package
+  type: git
+  location: https://github.com/anka-213/dependent-sum
+  tag: 8cf4c7fbc3bfa2be475a17bb7c94a1e1e9a830b5
+  subdir: dependent-sum-template
+-- https://github.com/obsidiansystems/dependent-sum/pull/57

--- a/cabal.project
+++ b/cabal.project
@@ -15,3 +15,23 @@ constraints: some == 1.0.1,
              dependent-sum == 0.7.1.0
 
 max-backjumps: 10000
+
+allow-newer:
+  lens:template-haskell,
+  parallel:base,
+  hashable:base,
+  async:base,
+  quickcheck-instances:base,
+  time-compat:base,
+  these:base,
+  assoc:base,
+  cryptohash-sha1:base,
+  cryptohash-md5:base,
+  split:base,
+  constraints-extras:base,
+  constraints-extras:template-haskell,
+  dependent-sum:some,
+  hslogger:base,
+  entropy:Cabal,
+  lens:Cabal
+

--- a/cabal.project
+++ b/cabal.project
@@ -11,11 +11,6 @@ benchmarks: True
 test-show-details: direct
 haddock-quickjump: True
 
-constraints: some == 1.0.1,
-             dependent-sum == 0.7.1.0
-
-max-backjumps: 10000
-
 allow-newer:
   lens:template-haskell,
   cryptohash-sha1:base,

--- a/lsp-test/func-test/func-test.cabal
+++ b/lsp-test/func-test/func-test.cabal
@@ -6,7 +6,7 @@ build-type:          Simple
 test-suite func-test
   main-is:             FuncTest.hs
   type:                exitcode-stdio-1.0
-  build-depends:       base <4.15
+  build-depends:       base <4.16
                      , lsp-test
                      , lsp
                      , data-default

--- a/lsp-test/lsp-test.cabal
+++ b/lsp-test/lsp-test.cabal
@@ -5,7 +5,7 @@ description:
   A test framework for writing tests against
   <https://microsoft.github.io/language-server-protocol/ Language Server Protocol servers>.
   @Language.LSP.Test@ launches your server as a subprocess and allows you to simulate a session
-  down to the wire. 
+  down to the wire.
   To see examples of it in action, check out <https://github.com/haskell/haskell-ide-engine haskell-ide-engine>,
   <https://github.com/haskell/haskell-language-server haskell-language-server> and
   <https://github.com/digital-asset/ghcide ghcide>.
@@ -98,7 +98,7 @@ test-suite func-test
   main-is:             FuncTest.hs
   hs-source-dirs:      func-test
   type:                exitcode-stdio-1.0
-  build-depends:       base <4.15
+  build-depends:       base <4.16
                      , lsp-test
                      , lsp
                      , data-default
@@ -109,7 +109,7 @@ test-suite func-test
                      , async
   default-language:    Haskell2010
 
-test-suite example 
+test-suite example
   main-is:             Test.hs
   hs-source-dirs:      example
   type:                exitcode-stdio-1.0
@@ -123,7 +123,7 @@ benchmark simple-bench
   main-is:             SimpleBench.hs
   hs-source-dirs:      bench
   type:                exitcode-stdio-1.0
-  build-depends:       base <4.15
+  build-depends:       base <4.16
                      , lsp-test
                      , lsp
                      , process

--- a/lsp-types/lsp-types.cabal
+++ b/lsp-types/lsp-types.cabal
@@ -69,7 +69,7 @@ library
                      , Language.LSP.Types.WorkspaceSymbol
  -- other-extensions:
   ghc-options:         -Wall
-  build-depends:       base >= 4.11 && < 4.15
+  build-depends:       base >= 4.11 && < 4.16
                      , aeson >=1.2.2.0
                      , binary
                      , bytestring

--- a/lsp-types/src/Language/LSP/Types/Method.hs
+++ b/lsp-types/src/Language/LSP/Types/Method.hs
@@ -312,7 +312,6 @@ instance A.FromJSON SomeServerMethod where
   parseJSON _                                                = fail "SomeServerMethod"
 
 -- instance FromJSON (SMethod m)
-makeSingletonFromJSON 'SomeMethod ''SMethod
 
 -- ---------------------------------------------------------------------
 -- TO JSON
@@ -396,3 +395,5 @@ instance A.ToJSON (SMethod m) where
   toJSON SCancelRequest                      = A.String "$/cancelRequest"
 -- Custom
   toJSON (SCustomMethod m)                   = A.String m
+
+makeSingletonFromJSON 'SomeMethod ''SMethod

--- a/lsp-types/src/Language/LSP/Types/TextDocument.hs
+++ b/lsp-types/src/Language/LSP/Types/TextDocument.hs
@@ -84,6 +84,7 @@ data SaveOptions =
   { -- | The client is supposed to include the content on save.
     _includeText :: Maybe Bool
   } deriving (Show, Read, Eq)
+deriveJSON lspOptions ''SaveOptions
 
 -- -------------------------------------
 
@@ -107,7 +108,7 @@ instance FromJSON TextDocumentSyncKind where
   parseJSON (Number 1) = pure TdSyncFull
   parseJSON (Number 2) = pure TdSyncIncremental
   parseJSON _          = fail "TextDocumentSyncKind"
-  
+
 data TextDocumentSyncOptions =
   TextDocumentSyncOptions
   { -- | Open and close notifications are sent to the server. If omitted open
@@ -234,7 +235,6 @@ deriveJSON lspOptions ''WillSaveTextDocumentParams
 
 -- -------------------------------------
 
-deriveJSON lspOptions ''SaveOptions
 
 makeExtendingDatatype "TextDocumentSaveRegistrationOptions"
   [''TextDocumentRegistrationOptions]

--- a/lsp-types/src/Language/LSP/Types/WatchedFiles.hs
+++ b/lsp-types/src/Language/LSP/Types/WatchedFiles.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 
 module Language.LSP.Types.WatchedFiles where
-  
+
 import Data.Aeson
 import Data.Aeson.TH
 import Data.Bits
@@ -71,9 +71,8 @@ instance FromJSON WatchKind where
     | otherwise = fail "WatchKind"
   parseJSON _            = fail "WatchKind"
 
-deriveJSON lspOptions ''DidChangeWatchedFilesRegistrationOptions
 deriveJSON lspOptions ''FileSystemWatcher
-
+deriveJSON lspOptions ''DidChangeWatchedFilesRegistrationOptions
 -- | The file event type.
 data FileChangeType = FcCreated -- ^ The file got created.
                     | FcChanged -- ^ The file got changed.

--- a/lsp/lsp.cabal
+++ b/lsp/lsp.cabal
@@ -31,7 +31,7 @@ library
                      , Language.LSP.Server.Control
                      , Language.LSP.Server.Processing
   ghc-options:         -Wall
-  build-depends:       base >= 4.11 && < 4.15
+  build-depends:       base >= 4.11 && < 4.16
                      , async
                      , aeson >=1.0.0.0
                      , attoparsec

--- a/lsp/lsp.cabal
+++ b/lsp/lsp.cabal
@@ -69,7 +69,7 @@ executable lsp-demo-reactor-server
   default-language:    Haskell2010
   ghc-options:         -Wall -Wno-unticked-promoted-constructors
 
-  build-depends:       base >= 4.11 && < 4.15
+  build-depends:       base >= 4.11 && < 4.16
                      , aeson
                      , bytestring
                      , containers


### PR DESCRIPTION
This integrates the changes from #281 and also fixes some Template Haskell issues caused by [ghc-9.0.1 having stricter staging rules than earlier versions](https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.0#the-order-of-th-splices-is-more-important).

(Step towards https://github.com/haskell/haskell-language-server/issues/297)