### PR TITLE
Improve error messages on JSON decode failures

### DIFF
--- a/lsp-test/src/Language/LSP/Test/Decoding.hs
+++ b/lsp-test/src/Language/LSP/Test/Decoding.hs
@@ -83,15 +83,16 @@ getRequestMap = foldl' helper emptyIxMap
     _ -> acc
 
 decodeFromServerMsg :: RequestMap -> B.ByteString -> (RequestMap, FromServerMessage)
-decodeFromServerMsg reqMap bytes = unP $ fromJust $ parseMaybe p obj
+decodeFromServerMsg reqMap bytes = unP $ parse p obj
   where obj = fromJust $ decode bytes :: Value
         p = parseServerMessage $ \lid ->
           let (mm, newMap) = pickFromIxMap lid reqMap
             in case mm of
               Nothing -> Nothing
               Just m -> Just $ (m, Pair m (Const newMap))
-        unP (FromServerMess m msg) = (reqMap, FromServerMess m msg)
-        unP (FromServerRsp (Pair m (Const newMap)) msg) = (newMap, FromServerRsp m msg)
+        unP (Success (FromServerMess m msg)) = (reqMap, FromServerMess m msg)
+        unP (Success (FromServerRsp (Pair m (Const newMap)) msg)) = (newMap, FromServerRsp m msg)
+        unP (Error e) = error e
         {-
         WorkspaceWorkspaceFolders      -> error "ReqWorkspaceFolders not supported yet"
         WorkspaceConfiguration         -> error "ReqWorkspaceConfiguration not supported yet"

--- a/lsp-types/src/Language/LSP/Types/CodeAction.hs
+++ b/lsp-types/src/Language/LSP/Types/CodeAction.hs
@@ -83,7 +83,7 @@ instance FromJSON CodeActionKind where
   parseJSON (String "source")                 = pure CodeActionSource
   parseJSON (String "source.organizeImports") = pure CodeActionSourceOrganizeImports
   parseJSON (String s)                        = pure (CodeActionUnknown s)
-  parseJSON _                                 = mempty
+  parseJSON _                                 = fail "CodeActionKind"
   
 -- -------------------------------------
 

--- a/lsp-types/src/Language/LSP/Types/Common.hs
+++ b/lsp-types/src/Language/LSP/Types/Common.hs
@@ -54,4 +54,4 @@ instance ToJSON Empty where
   toJSON Empty = Null
 instance FromJSON Empty where
   parseJSON Null = pure Empty
-  parseJSON _ = mempty
+  parseJSON _ = fail "expected 'null'"

--- a/lsp-types/src/Language/LSP/Types/Completion.hs
+++ b/lsp-types/src/Language/LSP/Types/Completion.hs
@@ -96,7 +96,7 @@ instance A.FromJSON CompletionItemKind where
   parseJSON (A.Number 23) = pure CiEvent
   parseJSON (A.Number 24) = pure CiOperator
   parseJSON (A.Number 25) = pure CiTypeParameter
-  parseJSON _             = mempty
+  parseJSON _             = fail "CompletionItemKind"
 
 data CompletionItemTag
   -- | Render a completion as obsolete, usually using a strike-out.
@@ -110,7 +110,7 @@ instance A.ToJSON CompletionItemTag where
 
 instance A.FromJSON CompletionItemTag where
   parseJSON (A.Number 1) = pure CitDeprecated
-  parseJSON _            = mempty
+  parseJSON _            = fail "CompletionItemTag"
 
 data CompletionItemTagsClientCapabilities =
   CompletionItemTagsClientCapabilities
@@ -158,7 +158,7 @@ instance A.ToJSON InsertTextMode where
 instance A.FromJSON InsertTextMode where
   parseJSON (A.Number 1) = pure AsIs
   parseJSON (A.Number 2) = pure AdjustIndentation
-  parseJSON _          = mempty
+  parseJSON _            = fail "InsertTextMode"
 
 data CompletionItemInsertTextModeClientCapabilities =
   CompletionItemInsertTextModeClientCapabilities
@@ -263,7 +263,7 @@ instance A.ToJSON InsertTextFormat where
 instance A.FromJSON InsertTextFormat where
   parseJSON (A.Number  1) = pure PlainText
   parseJSON (A.Number  2) = pure Snippet
-  parseJSON _             = mempty
+  parseJSON _             = fail "InsertTextFormat"
 
 data CompletionDoc = CompletionDocString Text
                    | CompletionDocMarkup MarkupContent
@@ -381,7 +381,7 @@ instance A.FromJSON CompletionTriggerKind where
   parseJSON (A.Number 2) = pure CtTriggerCharacter
   parseJSON (A.Number 3) = pure CtTriggerForIncompleteCompletions
   parseJSON (A.Number x) = pure (CtUnknown x)
-  parseJSON _          = mempty
+  parseJSON _            = fail "CompletionTriggerKind"
 
 makeExtendingDatatype "CompletionOptions" [''WorkDoneProgressOptions]
   [ ("_triggerCharacters", [t| Maybe [Text] |])

--- a/lsp-types/src/Language/LSP/Types/Diagnostic.hs
+++ b/lsp-types/src/Language/LSP/Types/Diagnostic.hs
@@ -37,7 +37,7 @@ instance A.FromJSON DiagnosticSeverity where
   parseJSON (A.Number 2) = pure DsWarning
   parseJSON (A.Number 3) = pure DsInfo
   parseJSON (A.Number 4) = pure DsHint
-  parseJSON _            = mempty
+  parseJSON _            = fail "DiagnosticSeverity"
 
 data DiagnosticTag
   -- | Unused or unnecessary code.
@@ -61,7 +61,7 @@ instance A.ToJSON DiagnosticTag where
 instance A.FromJSON DiagnosticTag where
   parseJSON (A.Number 1) = pure DtUnnecessary
   parseJSON (A.Number 2) = pure DtDeprecated
-  parseJSON _            = mempty
+  parseJSON _            = fail "DiagnosticTag"
 
 -- ---------------------------------------------------------------------
 

--- a/lsp-types/src/Language/LSP/Types/DocumentHighlight.hs
+++ b/lsp-types/src/Language/LSP/Types/DocumentHighlight.hs
@@ -53,7 +53,7 @@ instance FromJSON DocumentHighlightKind where
   parseJSON (Number 1) = pure HkText
   parseJSON (Number 2) = pure HkRead
   parseJSON (Number 3) = pure HkWrite
-  parseJSON _            = mempty
+  parseJSON _          = mempty "DocumentHighlightKind"
 
 -- -------------------------------------
 

--- a/lsp-types/src/Language/LSP/Types/DocumentSymbol.hs
+++ b/lsp-types/src/Language/LSP/Types/DocumentSymbol.hs
@@ -124,7 +124,7 @@ instance FromJSON SymbolKind where
   parseJSON (Number 25) = pure SkOperator
   parseJSON (Number 26) = pure SkTypeParameter
   parseJSON (Number x)  = pure (SkUnknown x)
-  parseJSON _           = mempty
+  parseJSON _           = fail "SymbolKind"
 
 {-|
 Symbol tags are extra annotations that tweak the rendering of a symbol.
@@ -143,7 +143,7 @@ instance ToJSON SymbolTag where
 instance FromJSON SymbolTag where
   parseJSON (Number  1) = pure StDeprecated
   parseJSON (Number x)  = pure (StUnknown x)
-  parseJSON _           = mempty
+  parseJSON _           = fail "SymbolTag"
   
 -- -------------------------------------
 

--- a/lsp-types/src/Language/LSP/Types/FoldingRange.hs
+++ b/lsp-types/src/Language/LSP/Types/FoldingRange.hs
@@ -73,7 +73,7 @@ instance A.FromJSON FoldingRangeKind where
   parseJSON (A.String "imports") = pure FoldingRangeImports
   parseJSON (A.String "region")  = pure FoldingRangeRegion
   parseJSON (A.String x)         = pure (FoldingRangeUnknown x)
-  parseJSON _                    = mempty
+  parseJSON _                    = fail "FoldingRangeKind"
 
 -- | Represents a folding range.
 data FoldingRange =

--- a/lsp-types/src/Language/LSP/Types/Initialize.hs
+++ b/lsp-types/src/Language/LSP/Types/Initialize.hs
@@ -28,8 +28,8 @@ instance FromJSON Trace where
     "off"      -> return TraceOff
     "messages" -> return TraceMessages
     "verbose"  -> return TraceVerbose
-    _          -> mempty
-  parseJSON _          = mempty
+    _          -> fail "Trace"
+  parseJSON _          = fail "Trace"
 
 data ClientInfo =
   ClientInfo
@@ -89,7 +89,7 @@ data InitializedParams =
 
 instance FromJSON InitializedParams where
   parseJSON (Object _) = pure InitializedParams
-  parseJSON _            = mempty
+  parseJSON _          = fail "InitializedParams"
 
 instance ToJSON InitializedParams where
   toJSON InitializedParams = Object mempty

--- a/lsp-types/src/Language/LSP/Types/LspId.hs
+++ b/lsp-types/src/Language/LSP/Types/LspId.hs
@@ -22,7 +22,7 @@ instance A.ToJSON (LspId m) where
 instance A.FromJSON (LspId m) where
   parseJSON v@(A.Number _) = IdInt <$> A.parseJSON v
   parseJSON  (A.String  s) = return (IdString s)
-  parseJSON _              = mempty
+  parseJSON _              = fail "LspId"
 
 instance IxOrd LspId where
   type Base LspId = SomeLspId

--- a/lsp-types/src/Language/LSP/Types/MarkupContent.hs
+++ b/lsp-types/src/Language/LSP/Types/MarkupContent.hs
@@ -27,7 +27,7 @@ instance ToJSON MarkupKind where
 instance FromJSON MarkupKind where
   parseJSON (String "plaintext") = pure MkPlainText
   parseJSON (String "markdown")  = pure MkMarkdown
-  parseJSON _                    = mempty
+  parseJSON _                    = fail "MarkupKind"
 
 -- | A `MarkupContent` literal represents a string value which content is interpreted base on its
 -- | kind flag. Currently the protocol supports `plaintext` and `markdown` as markup kinds.

--- a/lsp-types/src/Language/LSP/Types/Message.hs
+++ b/lsp-types/src/Language/LSP/Types/Message.hs
@@ -322,7 +322,7 @@ instance FromJSON ErrorCode where
   parseJSON (Number (-32001)) = pure UnknownErrorCode
   parseJSON (Number (-32800)) = pure RequestCancelled
   parseJSON (Number (-32801)) = pure ContentModified
-  parseJSON _                   = mempty
+  parseJSON _                 = fail "ErrorCode"
 
 -- -------------------------------------
 

--- a/lsp-types/src/Language/LSP/Types/Method.hs
+++ b/lsp-types/src/Language/LSP/Types/Method.hs
@@ -273,7 +273,7 @@ instance FromJSON SomeClientMethod where
   parseJSON (A.String "$/cancelRequest")                     = pure $ SomeClientMethod SCancelRequest
 -- Custom
   parseJSON (A.String m)                                     = pure $ SomeClientMethod (SCustomMethod m)
-  parseJSON _                                                = mempty
+  parseJSON _                                                = fail "SomeClientMethod"
 
 instance A.FromJSON SomeServerMethod where
 -- Server
@@ -299,7 +299,7 @@ instance A.FromJSON SomeServerMethod where
 
 -- Custom
   parseJSON (A.String m)                                     = pure $ SomeServerMethod (SCustomMethod m)
-  parseJSON _                                                = mempty
+  parseJSON _                                                = fail "SomeServerMethod"
 
 -- instance FromJSON (SMethod m)
 makeSingletonFromJSON 'SomeMethod ''SMethod

--- a/lsp-types/src/Language/LSP/Types/Rename.hs
+++ b/lsp-types/src/Language/LSP/Types/Rename.hs
@@ -24,7 +24,7 @@ instance ToJSON PrepareSupportDefaultBehavior where
 
 instance FromJSON PrepareSupportDefaultBehavior where
   parseJSON (Number 1) = pure PsIdentifier
-  parseJSON _          = mempty
+  parseJSON _          = fail "PrepareSupportDefaultBehavior"
 
 data RenameClientCapabilities =
   RenameClientCapabilities

--- a/lsp-types/src/Language/LSP/Types/SignatureHelp.hs
+++ b/lsp-types/src/Language/LSP/Types/SignatureHelp.hs
@@ -99,8 +99,8 @@ instance FromJSON ParameterLabel where
         is <- parseJSON v
         case is of
           [l, h] -> pure $ ParameterLabelOffset l h
-          _ -> mempty
-      parseInterval _ = mempty
+          _ -> fail "ParameterLabel"
+      parseInterval _ = fail "ParameterLabel"
 
 -- -------------------------------------
 
@@ -166,7 +166,7 @@ instance FromJSON SignatureHelpTriggerKind where
   parseJSON (Number 1) = pure SHTKInvoked
   parseJSON (Number 2) = pure SHTKTriggerCharacter
   parseJSON (Number 3) = pure SHTKContentChange
-  parseJSON _          = mempty
+  parseJSON _          = fail "SignatureHelpTriggerKind"
 
 -- | Additional information about the context in which a signature help request
 -- was triggered.

--- a/lsp-types/src/Language/LSP/Types/TextDocument.hs
+++ b/lsp-types/src/Language/LSP/Types/TextDocument.hs
@@ -106,7 +106,7 @@ instance FromJSON TextDocumentSyncKind where
   parseJSON (Number 0) = pure TdSyncNone
   parseJSON (Number 1) = pure TdSyncFull
   parseJSON (Number 2) = pure TdSyncIncremental
-  parseJSON _            = mempty
+  parseJSON _          = fail "TextDocumentSyncKind"
   
 data TextDocumentSyncOptions =
   TextDocumentSyncOptions
@@ -220,7 +220,7 @@ instance FromJSON TextDocumentSaveReason where
   parseJSON (Number 1) = pure SaveManual
   parseJSON (Number 2) = pure SaveAfterDelay
   parseJSON (Number 3) = pure SaveFocusOut
-  parseJSON _          = mempty
+  parseJSON _          = fail "TextDocumentSaveReason"
 
 data WillSaveTextDocumentParams =
   WillSaveTextDocumentParams

--- a/lsp-types/src/Language/LSP/Types/WatchedFiles.hs
+++ b/lsp-types/src/Language/LSP/Types/WatchedFiles.hs
@@ -68,8 +68,8 @@ instance FromJSON WatchKind where
     | Right i <- floatingOrInteger n :: Either Double Int
     , 0 <= i && i <= 7 =
         pure $ WatchKind (testBit i 0x0) (testBit i 0x1) (testBit i 0x2)
-    | otherwise = mempty
-  parseJSON _            = mempty
+    | otherwise = fail "WatchKind"
+  parseJSON _            = fail "WatchKind"
 
 deriveJSON lspOptions ''DidChangeWatchedFilesRegistrationOptions
 deriveJSON lspOptions ''FileSystemWatcher
@@ -89,7 +89,7 @@ instance FromJSON FileChangeType where
   parseJSON (Number 1) = pure FcCreated
   parseJSON (Number 2) = pure FcChanged
   parseJSON (Number 3) = pure FcDeleted
-  parseJSON _            = mempty
+  parseJSON _          = fail "FileChangetype"
 
 
 -- -------------------------------------

--- a/lsp-types/src/Language/LSP/Types/Window.hs
+++ b/lsp-types/src/Language/LSP/Types/Window.hs
@@ -28,7 +28,7 @@ instance A.FromJSON MessageType where
   parseJSON (A.Number 2) = pure MtWarning
   parseJSON (A.Number 3) = pure MtInfo
   parseJSON (A.Number 4) = pure MtLog
-  parseJSON _            = mempty
+  parseJSON _            = fail "MessageType"
 
 -- ---------------------------------------
 

--- a/lsp-types/src/Language/LSP/Types/WorkspaceEdit.hs
+++ b/lsp-types/src/Language/LSP/Types/WorkspaceEdit.hs
@@ -276,7 +276,7 @@ instance FromJSON ResourceOperationKind where
   parseJSON (String "create") = pure ResourceOperationCreate
   parseJSON (String "rename") = pure ResourceOperationRename
   parseJSON (String "delete") = pure ResourceOperationDelete
-  parseJSON _                 = mempty
+  parseJSON _                 = fail "ResourceOperationKind"
 
 data FailureHandlingKind
   = FailureHandlingAbort -- ^ Applying the workspace change is simply aborted if one of the changes provided fails. All operations executed before the failing operation stay executed.
@@ -296,7 +296,7 @@ instance FromJSON FailureHandlingKind where
   parseJSON (String "transactional")         = pure FailureHandlingTransactional
   parseJSON (String "textOnlyTransactional") = pure FailureHandlingTextOnlyTransactional
   parseJSON (String "undo")                  = pure FailureHandlingUndo
-  parseJSON _                                = mempty
+  parseJSON _                                = fail "FailureHandlingKind"
 
 data WorkspaceEditChangeAnnotationClientCapabilities =
   WorkspaceEditChangeAnnotationClientCapabilities


### PR DESCRIPTION
If we receive a JSON payload from the LSP server which has unexpected
values for some fields, 'Aeson.parseMaybe' fails and the program crashes
because of 'fromJust'. Make two improvements:

* Use 'Aeson.parse' instead to get an error message
* In 'Aeson.FromJSON' instances, avoid 'mempty'; use 'fail'
  to give a more helpful message instead. (I would have used
  'Aeson.parseFail', but older versions of Aeson don't have that
  function.)

Example before:

    myprogram: Maybe.fromJust: Nothing
    CallStack (from HasCallStack):
      error, called at libraries/base/Data/Maybe.hs:148:21 in base:Data.Maybe
      fromJust, called at src/Language/LSP/Test/Decoding.hs:86:42 in lsp-test-0.14.0.0-6s4OGLFS3RcJa58gpuLS2v:Language.LSP.Test.Decoding

Example after:

    myprogram: expected 'null'
    CallStack (from HasCallStack):
      error, called at src/Language/LSP/Test/Decoding.hs:95:25 in lsp-test-0.14.0.0-6s4OGLFS3RcJa58gpuLS2v:Language.LSP.Test.Decoding
