### PR TITLE
Do not crash on workspace/didChangeConfiguration

### DIFF
--- a/lsp-types/src/Language/LSP/Types/Common.hs
+++ b/lsp-types/src/Language/LSP/Types/Common.hs
@@ -9,6 +9,7 @@ module Language.LSP.Types.Common where
 import Control.Applicative
 import Control.DeepSeq
 import Data.Aeson
+import qualified Data.HashMap.Strict as HashMap
 import GHC.Generics
 
 -- | A terser, isomorphic data type for 'Either', that does not get tagged when
@@ -54,4 +55,5 @@ instance ToJSON Empty where
   toJSON Empty = Null
 instance FromJSON Empty where
   parseJSON Null = pure Empty
-  parseJSON _ = fail "expected 'null'"
+  parseJSON (Object o) | HashMap.null o = pure Empty
+  parseJSON _ = fail "expected 'null' or '{}'"

--- a/lsp/test/ServerCapabilitiesSpec.hs
+++ b/lsp/test/ServerCapabilitiesSpec.hs
@@ -28,6 +28,13 @@ spec = describe "server capabilities" $ do
     let input = "{\"hoverProvider\": true, \"colorProvider\": {\"id\": \"abc123\", \"documentSelector\": " <> documentFiltersJson <> "}}"
         Just caps = decode input :: Maybe ServerCapabilities
       in caps ^. colorProvider `shouldBe` Just (InR $ InR $ DocumentColorRegistrationOptions (Just documentFilters) (Just "abc123") Nothing)
+  describe "client/registerCapability" $
+    it "allows empty registerOptions" $
+      let input = "{\"registrations\":[{\"registerOptions\":{},\"method\":\"workspace/didChangeConfiguration\",\"id\":\"4a56f5ca-7188-4f4c-a366-652d6f9d63aa\"}]}"
+          Just registrationParams = decode input :: Maybe RegistrationParams
+        in registrationParams ^. registrations `shouldBe`
+             List [SomeRegistration $ Registration "4a56f5ca-7188-4f4c-a366-652d6f9d63aa"
+                                      SWorkspaceDidChangeConfiguration Empty]
   where
     documentFilters = List [DocumentFilter (Just "haskell") Nothing Nothing]
     documentFiltersJson = "[{\"language\": \"haskell\"}]"


### PR DESCRIPTION
The eslint-server LSP server sends the following message to the client:

    {
        "jsonrpc": "2.0",
        "params": {
            "registrations": [
                {
                    "registerOptions": {},
                    "method": "workspace/didChangeConfiguration",
                    "id": "4a56f5ca-7188-4f4c-a366-652d6f9d63aa"
                }
            ]
        },
        "method": "client/registerCapability",
        "id": 0
    }

This crashes lsp-test because it asserts that registerOptions is null
(but an empty object is not null).

Make lsp-test accept either null or an object.

Warning: This commit affects every use of Empty, not just
WorkspaceDidChangeConfiguration.