### PR TITLE
Call hierarchy support

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -10,3 +10,8 @@ tests: True
 benchmarks: True
 test-show-details: direct
 haddock-quickjump: True
+
+constraints: some == 1.0.1,
+             dependent-sum == 0.7.1.0
+
+max-backjumps: 10000

--- a/lsp-test/src/Language/LSP/Test.hs
+++ b/lsp-test/src/Language/LSP/Test.hs
@@ -95,6 +95,8 @@ module Language.LSP.Test
   -- ** Capabilities
   , getRegisteredCapabilities
   , prepareCallHierarchy
+  , incomingCalls
+  , outgoingCalls
   ) where
 
 import Control.Applicative.Combinators
@@ -750,8 +752,19 @@ getRegisteredCapabilities = Map.elems . curDynCaps <$> get
 
 -- | Pass a param and return the response from `prepareCallHierarchy`
 prepareCallHierarchy :: CallHierarchyPrepareParams -> Session [CallHierarchyItem]
-prepareCallHierarchy params = do
-  rsp <- request STextDocumentPrepareCallHierarchy params
+prepareCallHierarchy = resolveRequestWithListResp STextDocumentPrepareCallHierarchy
+
+incomingCalls :: CallHierarchyIncomingCallsParams -> Session [CallHierarchyIncomingCall]
+incomingCalls = resolveRequestWithListResp SCallHierarchyIncomingCalls
+
+outgoingCalls :: CallHierarchyOutgoingCallsParams -> Session [CallHierarchyOutgoingCall]
+outgoingCalls = resolveRequestWithListResp SCallHierarchyOutgoingCalls
+
+-- | Send a request and receive a 
+resolveRequestWithListResp :: (ResponseResult m ~ Maybe (List a))
+               => SClientMethod m -> MessageParams m -> Session [a]
+resolveRequestWithListResp method params = do
+  rsp <- request method params
   case getResponseResult rsp of
     Nothing -> pure []
-    Just (List x)  -> pure x
+    Just (List x) -> pure x

--- a/lsp-test/src/Language/LSP/Test.hs
+++ b/lsp-test/src/Language/LSP/Test.hs
@@ -760,7 +760,7 @@ incomingCalls = resolveRequestWithListResp SCallHierarchyIncomingCalls
 outgoingCalls :: CallHierarchyOutgoingCallsParams -> Session [CallHierarchyOutgoingCall]
 outgoingCalls = resolveRequestWithListResp SCallHierarchyOutgoingCalls
 
--- | Send a request and receive a 
+-- | Send a request and receive a response with list.
 resolveRequestWithListResp :: (ResponseResult m ~ Maybe (List a))
                => SClientMethod m -> MessageParams m -> Session [a]
 resolveRequestWithListResp method params = do

--- a/lsp-test/src/Language/LSP/Test.hs
+++ b/lsp-test/src/Language/LSP/Test.hs
@@ -94,6 +94,7 @@ module Language.LSP.Test
   , getCodeLenses
   -- ** Capabilities
   , getRegisteredCapabilities
+  , prepareCallHierarchy
   ) where
 
 import Control.Applicative.Combinators
@@ -163,7 +164,7 @@ runSessionWithConfig config' serverExe caps rootDir session = do
 --
 -- > (hinRead, hinWrite) <- createPipe
 -- > (houtRead, houtWrite) <- createPipe
--- > 
+-- >
 -- > forkIO $ void $ runServerWithHandles hinRead houtWrite serverDefinition
 -- > runSessionWithHandles hinWrite houtRead defaultConfig fullCaps "." $ do
 -- >   -- ...
@@ -656,7 +657,7 @@ getDefinitions = getDeclarationyRequest STextDocumentDefinition DefinitionParams
 getTypeDefinitions :: TextDocumentIdentifier -- ^ The document the term is in.
                    -> Position -- ^ The position the term is at.
                    -> Session ([Location] |? [LocationLink])
-getTypeDefinitions = getDeclarationyRequest STextDocumentTypeDefinition TypeDefinitionParams 
+getTypeDefinitions = getDeclarationyRequest STextDocumentTypeDefinition TypeDefinitionParams
 
 -- | Returns the type definition(s) for the term at the specified position.
 getImplementations :: TextDocumentIdentifier -- ^ The document the term is in.
@@ -746,3 +747,11 @@ getCodeLenses tId = do
 -- @since 0.11.0.0
 getRegisteredCapabilities :: Session [SomeRegistration]
 getRegisteredCapabilities = Map.elems . curDynCaps <$> get
+
+-- | Pass a param and return the response from `prepareCallHierarchy`
+prepareCallHierarchy :: CallHierarchyPrepareParams -> Session [CallHierarchyItem]
+prepareCallHierarchy params = do
+  rsp <- request STextDocumentPrepareCallHierarchy params
+  case getResponseResult rsp of
+    Nothing -> pure []
+    Just (List x)  -> pure x

--- a/lsp-test/test/DummyServer.hs
+++ b/lsp-test/test/DummyServer.hs
@@ -202,4 +202,14 @@ handlers =
         if x == 0 && y == 0
           then resp $ Right Nothing
           else resp $ Right $ Just $ List [item]
+     , requestHandler SCallHierarchyIncomingCalls $ \req resp -> do
+        let RequestMessage _ _ _ params = req
+            CallHierarchyIncomingCallsParams _ _ item = params
+        resp $ Right $ Just $
+          List [CallHierarchyIncomingCall item (List [Range (Position 2 3) (Position 4 5)])]
+     , requestHandler SCallHierarchyOutgoingCalls $ \req resp -> do
+        let RequestMessage _ _ _ params = req
+            CallHierarchyOutgoingCallsParams _ _ item = params
+        resp $ Right $ Just $
+          List [CallHierarchyOutgoingCall item (List [Range (Position 4 5) (Position 2 3)])]
     ]

--- a/lsp-test/test/DummyServer.hs
+++ b/lsp-test/test/DummyServer.hs
@@ -16,12 +16,12 @@ import System.Directory
 import System.FilePath
 import System.Process
 import Language.LSP.Types
-  
+
 withDummyServer :: ((Handle, Handle) -> IO ()) -> IO ()
 withDummyServer f = do
   (hinRead, hinWrite) <- createPipe
   (houtRead, houtWrite) <- createPipe
-  
+
   handlerEnv <- HandlerEnv <$> newEmptyMVar <*> newEmptyMVar
   let definition = ServerDefinition
         { doInitialize = \env _req -> pure $ Right env
@@ -185,4 +185,21 @@ handlers =
                 Nothing
                 Nothing
         resp $ Right $ InR res
+     , requestHandler STextDocumentPrepareCallHierarchy $ \req resp -> do
+        let RequestMessage _ _ _ params = req
+            CallHierarchyPrepareParams _ pos _ = params
+            Position x y = pos
+            item =
+              CallHierarchyItem
+                "foo"
+                SkMethod
+                Nothing
+                Nothing
+                (Uri "")
+                (Range (Position 2 3) (Position 4 5))
+                (Range (Position 2 3) (Position 4 5))
+                Nothing
+        if x == 0 && y == 0
+          then resp $ Right Nothing
+          else resp $ Right $ Just $ List [item]
     ]

--- a/lsp-test/test/Test.hs
+++ b/lsp-test/test/Test.hs
@@ -377,12 +377,23 @@ main = hspec $ around withDummyServer $ do
     let workPos = Position 1 0
         notWorkPos = Position 0 0
         params pos = CallHierarchyPrepareParams (TextDocumentIdentifier (Uri "")) pos Nothing
-    it "works" $ \(hin, hout) -> runSessionWithHandles hin hout def fullCaps "." $ do
+        item = CallHierarchyItem "foo" SkFunction Nothing Nothing (Uri "")
+                                 (Range (Position 1 2) (Position 3 4))
+                                 (Range (Position 1 2) (Position 3 4))
+                                 Nothing
+    it "prepare works" $ \(hin, hout) -> runSessionWithHandles hin hout def fullCaps "." $ do
       rsp <- prepareCallHierarchy (params workPos)
       liftIO $ head rsp ^. range `shouldBe` Range (Position 2 3) (Position 4 5)
-    it "not works" $ \(hin, hout) -> runSessionWithHandles hin hout def fullCaps "." $ do
+    it "prepare not works" $ \(hin, hout) -> runSessionWithHandles hin hout def fullCaps "." $ do
       rsp <- prepareCallHierarchy (params notWorkPos)
       liftIO $ rsp `shouldBe` []
+    it "incoming calls" $ \(hin, hout) -> runSessionWithHandles hin hout def fullCaps "." $ do
+      [CallHierarchyIncomingCall _ (List fromRanges)] <- incomingCalls (CallHierarchyIncomingCallsParams Nothing Nothing item)
+      liftIO $ head fromRanges `shouldBe` Range (Position 2 3) (Position 4 5)
+    it "outgoing calls" $ \(hin, hout) -> runSessionWithHandles hin hout def fullCaps "." $ do
+      [CallHierarchyOutgoingCall _ (List fromRanges)] <- outgoingCalls (CallHierarchyOutgoingCallsParams Nothing Nothing item)
+      liftIO $ head fromRanges `shouldBe` Range (Position 4 5) (Position 2 3)
+
 
 didChangeCaps :: ClientCapabilities
 didChangeCaps = def { _workspace = Just workspaceCaps }

--- a/lsp-test/test/Test.hs
+++ b/lsp-test/test/Test.hs
@@ -321,10 +321,10 @@ main = hspec $ around withDummyServer $ do
     it "works" $ \(hin, hout) ->
       runSessionWithHandles hin hout (def { ignoreLogNotifications = True }) fullCaps "." $ do
         openDoc "test/data/Format.hs" "haskell"
-        void publishDiagnosticsNotification       
+        void publishDiagnosticsNotification
 
   describe "dynamic capabilities" $ do
-    
+
     it "keeps track" $ \(hin, hout) -> runSessionWithHandles hin hout def fullCaps "." $ do
       loggingNotification -- initialized log message
 
@@ -373,6 +373,16 @@ main = hspec $ around withDummyServer $ do
       count 0 $ loggingNotification
       void $ anyResponse
 
+  describe "call hierarchy" $ do
+    let workPos = Position 1 0
+        notWorkPos = Position 0 0
+        params pos = CallHierarchyPrepareParams (TextDocumentIdentifier (Uri "")) pos Nothing
+    it "works" $ \(hin, hout) -> runSessionWithHandles hin hout def fullCaps "." $ do
+      rsp <- prepareCallHierarchy (params workPos)
+      liftIO $ head rsp ^. range `shouldBe` Range (Position 2 3) (Position 4 5)
+    it "not works" $ \(hin, hout) -> runSessionWithHandles hin hout def fullCaps "." $ do
+      rsp <- prepareCallHierarchy (params notWorkPos)
+      liftIO $ rsp `shouldBe` []
 
 didChangeCaps :: ClientCapabilities
 didChangeCaps = def { _workspace = Just workspaceCaps }

--- a/lsp-test/test/data/documentSymbolFail/example/Main.hs
+++ b/lsp-test/test/data/documentSymbolFail/example/Main.hs
@@ -68,6 +68,7 @@ main = do
         (Just (LSP.CodeLensClientCapabilities (Just False)))
         (Just (LSP.DocumentLinkClientCapabilities (Just False)))
         (Just (LSP.RenameClientCapabilities (Just False)))
+        (Just (LSP.CallHierarchyClientCapabilities (Just False)))
 
       initializeParams :: LSP.InitializeParams
       initializeParams = LSP.InitializeParams (Just pid) Nothing Nothing Nothing caps Nothing

--- a/lsp-types/lsp-types.cabal
+++ b/lsp-types/lsp-types.cabal
@@ -22,7 +22,8 @@ library
                      , Language.LSP.Types.Lens
                      , Language.LSP.VFS
                      , Data.IxMap
-  other-modules:       Language.LSP.Types.Cancellation
+  other-modules:       Language.LSP.Types.CallHierarchy
+                     , Language.LSP.Types.Cancellation
                      , Language.LSP.Types.ClientCapabilities
                      , Language.LSP.Types.CodeAction
                      , Language.LSP.Types.CodeLens

--- a/lsp-types/src/Language/LSP/Types.hs
+++ b/lsp-types/src/Language/LSP/Types.hs
@@ -1,5 +1,6 @@
 module Language.LSP.Types
-  ( module Language.LSP.Types.Cancellation
+  ( module Language.LSP.Types.CallHierarchy
+  , module Language.LSP.Types.Cancellation
   , module Language.LSP.Types.CodeAction
   , module Language.LSP.Types.CodeLens
   , module Language.LSP.Types.Command
@@ -43,6 +44,7 @@ module Language.LSP.Types
   )
 where
 
+import           Language.LSP.Types.CallHierarchy
 import           Language.LSP.Types.Cancellation
 import           Language.LSP.Types.CodeAction
 import           Language.LSP.Types.CodeLens

--- a/lsp-types/src/Language/LSP/Types/CallHierarchy.hs
+++ b/lsp-types/src/Language/LSP/Types/CallHierarchy.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 {- | Since LSP 3.16.0 -}
 module Language.LSP.Types.CallHierarchy where
@@ -8,13 +8,13 @@ import Data.Aeson.TH
 import Data.Aeson.Types ( Value )
 import Data.Text ( Text )
 
-import Language.LSP.Types.Progress
-import Language.LSP.Types.TextDocument
-import Language.LSP.Types.StaticRegistrationOptions
-import Language.LSP.Types.DocumentSymbol
-import Language.LSP.Types.Uri
-import Language.LSP.Types.Location
 import Language.LSP.Types.Common
+import Language.LSP.Types.DocumentSymbol
+import Language.LSP.Types.Location
+import Language.LSP.Types.Progress
+import Language.LSP.Types.StaticRegistrationOptions
+import Language.LSP.Types.TextDocument
+import Language.LSP.Types.Uri
 import Language.LSP.Types.Utils
 
 

--- a/lsp-types/src/Language/LSP/Types/CallHierarchy.hs
+++ b/lsp-types/src/Language/LSP/Types/CallHierarchy.hs
@@ -1,0 +1,100 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+
+{- | Since LSP 3.16.0 -}
+module Language.LSP.Types.CallHierarchy where
+
+import Data.Aeson.TH
+import Data.Aeson.Types ( Value )
+import Data.Text ( Text )
+
+import Language.LSP.Types.Progress
+import Language.LSP.Types.TextDocument
+import Language.LSP.Types.StaticRegistrationOptions
+import Language.LSP.Types.DocumentSymbol
+import Language.LSP.Types.Uri
+import Language.LSP.Types.Location
+import Language.LSP.Types.Common
+import Language.LSP.Types.Utils
+
+
+data CallHierarchyClientCapabilities =
+  CallHierarchyClientCapabilities
+    { _dynamicRegistration :: Maybe Bool }
+    deriving (Show, Read, Eq)
+deriveJSON lspOptions ''CallHierarchyClientCapabilities
+
+makeExtendingDatatype "CallHierarchyOptions" [''WorkDoneProgressOptions] []
+deriveJSON lspOptions ''CallHierarchyOptions
+
+makeExtendingDatatype "CallHierarchyRegistrartionOptions"
+  [ ''TextDocumentRegistrationOptions
+  , ''CallHierarchyOptions
+  , ''StaticRegistrationOptions
+  ]
+  []
+deriveJSON lspOptions ''CallHierarchyRegistrartionOptions
+
+makeExtendingDatatype "CallHierarchyPrepareParams"
+  [''TextDocumentPositionParams, ''WorkDoneProgressParams] []
+deriveJSON lspOptions ''CallHierarchyPrepareParams
+
+data CallHierarchyItem =
+  CallHierarchyItem
+    { _name :: Text
+    , _kind :: SymbolKind
+    , _tags :: Maybe (List SymbolTag)
+    -- | More detail for this item, e.g. the signature of a function.
+    , _detail :: Maybe Text
+    , _uri :: Uri
+    , _range :: Range
+    -- | The range that should be selected and revealed when this symbol
+    -- is being picked, e.g. the name of a function. Must be contained by
+    -- the @_range@.
+    , _selectionRange :: Range
+    -- | A data entry field that is preserved between a call hierarchy
+    -- prepare and incoming calls or outgoing calls requests.
+    , _xdata :: Maybe Value
+    }
+    deriving (Show, Read, Eq)
+deriveJSON lspOptions ''CallHierarchyItem
+
+-- -------------------------------------
+
+makeExtendingDatatype "CallHierarchyIncomingCallsParams"
+  [ ''WorkDoneProgressParams
+  , ''PartialResultParams
+  ]
+  [("_item", [t| CallHierarchyItem |])]
+deriveJSON lspOptions ''CallHierarchyIncomingCallsParams
+
+data CallHierarchyIncomingCall =
+  CallHierarchyIncomingCall
+    { -- | The item that makes the call.
+      _from :: CallHierarchyItem
+    -- | The ranges at which the calls appear. This is relative to the caller
+    -- denoted by @_from@.
+    , _fromRanges :: List Range
+    }
+    deriving (Show, Read, Eq)
+deriveJSON lspOptions ''CallHierarchyIncomingCall
+
+-- -------------------------------------
+
+makeExtendingDatatype "CallHierarchyOutgoingCallsParams"
+  [ ''WorkDoneProgressParams
+  , ''PartialResultParams
+  ]
+  [("_item", [t| CallHierarchyItem |])]
+deriveJSON lspOptions ''CallHierarchyOutgoingCallsParams
+
+data CallHierarchyOutgoingCall =
+  CallHierarchyOutgoingCall
+    { -- | The item that is called.
+      _to :: CallHierarchyItem
+    -- | The range at which this item is called. THis is the range relative to
+    -- the caller, e.g the item passed to `callHierarchy/outgoingCalls` request.
+    , _fromRanges :: List Range
+    }
+    deriving (Show, Read, Eq)
+deriveJSON lspOptions ''CallHierarchyOutgoingCall

--- a/lsp-types/src/Language/LSP/Types/CallHierarchy.hs
+++ b/lsp-types/src/Language/LSP/Types/CallHierarchy.hs
@@ -27,13 +27,13 @@ deriveJSON lspOptions ''CallHierarchyClientCapabilities
 makeExtendingDatatype "CallHierarchyOptions" [''WorkDoneProgressOptions] []
 deriveJSON lspOptions ''CallHierarchyOptions
 
-makeExtendingDatatype "CallHierarchyRegistrartionOptions"
+makeExtendingDatatype "CallHierarchyRegistrationOptions"
   [ ''TextDocumentRegistrationOptions
   , ''CallHierarchyOptions
   , ''StaticRegistrationOptions
   ]
   []
-deriveJSON lspOptions ''CallHierarchyRegistrartionOptions
+deriveJSON lspOptions ''CallHierarchyRegistrationOptions
 
 makeExtendingDatatype "CallHierarchyPrepareParams"
   [''TextDocumentPositionParams, ''WorkDoneProgressParams] []

--- a/lsp-types/src/Language/LSP/Types/Capabilities.hs
+++ b/lsp-types/src/Language/LSP/Types/Capabilities.hs
@@ -51,7 +51,7 @@ capsForVersion (LSPVersion maj min) = ClientCapabilities (Just w) (Just td) (Jus
           (Just (ExecuteCommandClientCapabilities dynamicReg))
           (since 3 6 True)
           (since 3 6 True)
-    
+
     resourceOperations = List
       [ ResourceOperationCreate
       , ResourceOperationDelete
@@ -126,6 +126,7 @@ capsForVersion (LSPVersion maj min) = ClientCapabilities (Just w) (Just td) (Jus
           (Just publishDiagnosticsCapabilities)
           (since 3 10 foldingRangeCapability)
           (since 3 5 (SelectionRangeClientCapabilities dynamicReg))
+          (since 3 16 (CallHierarchyClientCapabilities dynamicReg))
     sync =
       TextDocumentSyncClientCapabilities
         dynamicReg
@@ -266,5 +267,5 @@ capsForVersion (LSPVersion maj min) = ClientCapabilities (Just w) (Just td) (Jus
     since x y a
       | maj >= x && min >= y = Just a
       | otherwise            = Nothing
-    
+
     window = WindowClientCapabilities (since 3 15 True)

--- a/lsp-types/src/Language/LSP/Types/ClientCapabilities.hs
+++ b/lsp-types/src/Language/LSP/Types/ClientCapabilities.hs
@@ -32,6 +32,7 @@ import Language.LSP.Types.Utils
 import Language.LSP.Types.WatchedFiles
 import Language.LSP.Types.WorkspaceEdit
 import Language.LSP.Types.WorkspaceSymbol
+import Language.LSP.Types.CallHierarchy
 
 
 data WorkspaceClientCapabilities =
@@ -101,7 +102,7 @@ data TextDocumentClientCapabilities =
     , _onTypeFormatting :: Maybe DocumentOnTypeFormattingClientCapabilities
 
       -- | Capabilities specific to the `textDocument/declaration` request.
-      -- 
+      --
       -- Since LSP 3.14.0
     , _declaration :: Maybe DeclarationClientCapabilities
 
@@ -142,6 +143,10 @@ data TextDocumentClientCapabilities =
       -- | Capabilities specific to the `textDocument/selectionRange` request.
       -- Since LSP 3.15.0
     , _selectionRange :: Maybe SelectionRangeClientCapabilities
+
+      -- | Call hierarchy specific to the `textDocument/callHierarchy` request.
+      -- Since LSP 3.16.0
+    , _callHierarchy :: Maybe CallHierarchyClientCapabilities
     } deriving (Show, Read, Eq)
 
 deriveJSON lspOptions ''TextDocumentClientCapabilities
@@ -149,7 +154,7 @@ deriveJSON lspOptions ''TextDocumentClientCapabilities
 instance Default TextDocumentClientCapabilities where
   def = TextDocumentClientCapabilities def def def def def def def def
                                        def def def def def def def def
-                                       def def def def def def
+                                       def def def def def def def
 
 -- ---------------------------------------------------------------------
 

--- a/lsp-types/src/Language/LSP/Types/ClientCapabilities.hs
+++ b/lsp-types/src/Language/LSP/Types/ClientCapabilities.hs
@@ -144,7 +144,7 @@ data TextDocumentClientCapabilities =
       -- Since LSP 3.15.0
     , _selectionRange :: Maybe SelectionRangeClientCapabilities
 
-      -- | Call hierarchy specific to the `textDocument/callHierarchy` request.
+      -- | Call hierarchy specific to the `textDocument/prepareCallHierarchy` request.
       -- Since LSP 3.16.0
     , _callHierarchy :: Maybe CallHierarchyClientCapabilities
     } deriving (Show, Read, Eq)

--- a/lsp-types/src/Language/LSP/Types/ClientCapabilities.hs
+++ b/lsp-types/src/Language/LSP/Types/ClientCapabilities.hs
@@ -6,6 +6,7 @@ module Language.LSP.Types.ClientCapabilities where
 import           Data.Aeson.TH
 import qualified Data.Aeson as A
 import Data.Default
+import Language.LSP.Types.CallHierarchy
 import Language.LSP.Types.CodeAction
 import Language.LSP.Types.CodeLens
 import Language.LSP.Types.Command
@@ -32,7 +33,6 @@ import Language.LSP.Types.Utils
 import Language.LSP.Types.WatchedFiles
 import Language.LSP.Types.WorkspaceEdit
 import Language.LSP.Types.WorkspaceSymbol
-import Language.LSP.Types.CallHierarchy
 
 
 data WorkspaceClientCapabilities =

--- a/lsp-types/src/Language/LSP/Types/Lens.hs
+++ b/lsp-types/src/Language/LSP/Types/Lens.hs
@@ -359,7 +359,7 @@ makeFieldsNoPrefix ''StaticRegistrationOptions
 -- Call hierarchy
 makeFieldsNoPrefix ''CallHierarchyClientCapabilities
 makeFieldsNoPrefix ''CallHierarchyOptions
-makeFieldsNoPrefix ''CallHierarchyRegistrartionOptions
+makeFieldsNoPrefix ''CallHierarchyRegistrationOptions
 makeFieldsNoPrefix ''CallHierarchyPrepareParams
 makeFieldsNoPrefix ''CallHierarchyIncomingCallsParams
 makeFieldsNoPrefix ''CallHierarchyIncomingCall

--- a/lsp-types/src/Language/LSP/Types/Lens.hs
+++ b/lsp-types/src/Language/LSP/Types/Lens.hs
@@ -12,6 +12,7 @@
 
 module Language.LSP.Types.Lens where
 
+import           Language.LSP.Types.CallHierarchy
 import           Language.LSP.Types.Cancellation
 import           Language.LSP.Types.ClientCapabilities
 import           Language.LSP.Types.CodeAction
@@ -354,3 +355,14 @@ makeFieldsNoPrefix ''SignatureHelp
 
 -- Static registration
 makeFieldsNoPrefix ''StaticRegistrationOptions
+
+-- Call hierarchy
+makeFieldsNoPrefix ''CallHierarchyClientCapabilities
+makeFieldsNoPrefix ''CallHierarchyOptions
+makeFieldsNoPrefix ''CallHierarchyRegistrartionOptions
+makeFieldsNoPrefix ''CallHierarchyPrepareParams
+makeFieldsNoPrefix ''CallHierarchyIncomingCallsParams
+makeFieldsNoPrefix ''CallHierarchyIncomingCall
+makeFieldsNoPrefix ''CallHierarchyOutgoingCallsParams
+makeFieldsNoPrefix ''CallHierarchyOutgoingCall
+makeFieldsNoPrefix ''CallHierarchyItem

--- a/lsp-types/src/Language/LSP/Types/Message.hs
+++ b/lsp-types/src/Language/LSP/Types/Message.hs
@@ -17,6 +17,7 @@
 
 module Language.LSP.Types.Message where
 
+import           Language.LSP.Types.CallHierarchy
 import           Language.LSP.Types.Cancellation
 import           Language.LSP.Types.CodeAction
 import           Language.LSP.Types.CodeLens
@@ -120,6 +121,10 @@ type family MessageParams (m :: Method f t) :: Type where
   MessageParams TextDocumentFoldingRange           = FoldingRangeParams
   -- Selection Range
   MessageParams TextDocumentSelectionRange         = SelectionRangeParams
+  -- Call hierarchy
+  MessageParams TextDocumentPrepareCallHierarchy   = CallHierarchyPrepareParams
+  MessageParams CallHierarchyIncomingCalls         = CallHierarchyIncomingCallsParams
+  MessageParams CallHierarchyOutgoingCalls         = CallHierarchyOutgoingCallsParams
 -- Server
     -- Window
   MessageParams WindowShowMessage                  = ShowMessageParams
@@ -193,6 +198,10 @@ type family ResponseResult (m :: Method f Request) :: Type where
   -- FoldingRange
   ResponseResult TextDocumentFoldingRange      = List FoldingRange
   ResponseResult TextDocumentSelectionRange    = List SelectionRange
+  -- Call hierarchy
+  ResponseResult TextDocumentPrepareCallHierarchy = Maybe (List CallHierarchyItem)
+  ResponseResult CallHierarchyIncomingCalls    = Maybe (List CallHierarchyIncomingCall)
+  ResponseResult CallHierarchyOutgoingCalls    = Maybe (List CallHierarchyOutgoingCall)
   -- Custom can be either a notification or a message
 -- Server
   -- Window

--- a/lsp-types/src/Language/LSP/Types/Method.hs
+++ b/lsp-types/src/Language/LSP/Types/Method.hs
@@ -75,6 +75,10 @@ data Method (f :: From) (t :: MethodType) where
   -- FoldingRange
   TextDocumentFoldingRange           :: Method FromClient Request
   TextDocumentSelectionRange         :: Method FromClient Request
+  -- Call hierarchy
+  TextDocumentPrepareCallHierarchy   :: Method FromClient Request
+  CallHierarchyIncomingCalls         :: Method FromClient Request
+  CallHierarchyOutgoingCalls         :: Method FromClient Request
 
 -- ServerMethods
   -- Window
@@ -145,6 +149,9 @@ data SMethod (m :: Method f t) where
   STextDocumentPrepareRename          :: SMethod TextDocumentPrepareRename
   STextDocumentFoldingRange           :: SMethod TextDocumentFoldingRange
   STextDocumentSelectionRange         :: SMethod TextDocumentSelectionRange
+  STextDocumentPrepareCallHierarchy   :: SMethod TextDocumentPrepareCallHierarchy
+  SCallHierarchyIncomingCalls         :: SMethod CallHierarchyIncomingCalls
+  SCallHierarchyOutgoingCalls         :: SMethod CallHierarchyOutgoingCalls
 
   SWindowShowMessage                  :: SMethod WindowShowMessage
   SWindowShowMessageRequest           :: SMethod WindowShowMessageRequest
@@ -268,6 +275,9 @@ instance FromJSON SomeClientMethod where
   parseJSON (A.String "textDocument/prepareRename")          = pure $ SomeClientMethod STextDocumentPrepareRename
   parseJSON (A.String "textDocument/foldingRange")           = pure $ SomeClientMethod STextDocumentFoldingRange
   parseJSON (A.String "textDocument/selectionRange")         = pure $ SomeClientMethod STextDocumentFoldingRange
+  parseJSON (A.String "textDocument/prepareCallHierarchy")   = pure $ SomeClientMethod STextDocumentPrepareCallHierarchy
+  parseJSON (A.String "callHierarchy/incomingCalls")         = pure $ SomeClientMethod SCallHierarchyIncomingCalls
+  parseJSON (A.String "callHierarchy/outgoingCalls")         = pure $ SomeClientMethod SCallHierarchyOutgoingCalls
   parseJSON (A.String "window/workDoneProgress/cancel")      = pure $ SomeClientMethod SWindowWorkDoneProgressCancel
 -- Cancelling
   parseJSON (A.String "$/cancelRequest")                     = pure $ SomeClientMethod SCancelRequest
@@ -359,6 +369,9 @@ instance A.ToJSON (SMethod m) where
   toJSON STextDocumentPrepareRename          = A.String "textDocument/prepareRename"
   toJSON STextDocumentFoldingRange           = A.String "textDocument/foldingRange"
   toJSON STextDocumentSelectionRange         = A.String "textDocument/selectionRange"
+  toJSON STextDocumentPrepareCallHierarchy   = A.String "textDocument/prepareCallHierarchy"
+  toJSON SCallHierarchyIncomingCalls         = A.String "callHierarchy/incomingCalls"
+  toJSON SCallHierarchyOutgoingCalls         = A.String "callHierarchy/outgoingCalls"
   toJSON STextDocumentDocumentLink           = A.String "textDocument/documentLink"
   toJSON SDocumentLinkResolve                = A.String "documentLink/resolve"
   toJSON SWindowWorkDoneProgressCancel       = A.String "window/workDoneProgress/cancel"

--- a/lsp-types/src/Language/LSP/Types/Parsing.hs
+++ b/lsp-types/src/Language/LSP/Types/Parsing.hs
@@ -250,6 +250,9 @@ splitClientMethod STextDocumentRename = IsClientReq
 splitClientMethod STextDocumentPrepareRename = IsClientReq
 splitClientMethod STextDocumentFoldingRange = IsClientReq
 splitClientMethod STextDocumentSelectionRange = IsClientReq
+splitClientMethod STextDocumentPrepareCallHierarchy = IsClientReq
+splitClientMethod SCallHierarchyIncomingCalls = IsClientReq
+splitClientMethod SCallHierarchyOutgoingCalls = IsClientReq
 splitClientMethod SCancelRequest = IsClientNot
 splitClientMethod SCustomMethod{} = IsClientEither
 

--- a/lsp-types/src/Language/LSP/Types/Registration.hs
+++ b/lsp-types/src/Language/LSP/Types/Registration.hs
@@ -97,7 +97,7 @@ type family RegistrationOptions (m :: Method FromClient t) :: Type where
   RegistrationOptions TextDocumentRename                 = RenameRegistrationOptions
   RegistrationOptions TextDocumentFoldingRange           = FoldingRangeRegistrationOptions
   RegistrationOptions TextDocumentSelectionRange         = SelectionRangeRegistrationOptions
-  RegistrationOptions TextDocumentPrepareCallHierarchy   = CallHierarchyRegistrartionOptions
+  RegistrationOptions TextDocumentPrepareCallHierarchy   = CallHierarchyRegistrationOptions
   RegistrationOptions m                                  = Void
 
 data Registration (m :: Method FromClient t) =

--- a/lsp-types/src/Language/LSP/Types/Registration.hs
+++ b/lsp-types/src/Language/LSP/Types/Registration.hs
@@ -29,6 +29,7 @@ import           Data.Function (on)
 import           Data.Kind
 import           Data.Void (Void)
 import           GHC.Generics
+import           Language.LSP.Types.CallHierarchy
 import           Language.LSP.Types.CodeAction
 import           Language.LSP.Types.CodeLens
 import           Language.LSP.Types.Command
@@ -96,6 +97,7 @@ type family RegistrationOptions (m :: Method FromClient t) :: Type where
   RegistrationOptions TextDocumentRename                 = RenameRegistrationOptions
   RegistrationOptions TextDocumentFoldingRange           = FoldingRangeRegistrationOptions
   RegistrationOptions TextDocumentSelectionRange         = SelectionRangeRegistrationOptions
+  RegistrationOptions TextDocumentPrepareCallHierarchy   = CallHierarchyRegistrartionOptions
   RegistrationOptions m                                  = Void
 
 data Registration (m :: Method FromClient t) =

--- a/lsp-types/src/Language/LSP/Types/ServerCapabilities.hs
+++ b/lsp-types/src/Language/LSP/Types/ServerCapabilities.hs
@@ -118,11 +118,12 @@ data ServerCapabilities =
     , _executeCommandProvider           :: Maybe ExecuteCommandOptions
       -- | The server provides selection range support. Since LSP 3.15
     , _selectionRangeProvider           :: Maybe (Bool |? SelectionRangeOptions |? SelectionRangeRegistrationOptions)
+      -- | The server provides call hierarchy support.
+    , _callHierarchyProvider            :: Maybe (Bool |? CallHierarchyOptions |? CallHierarchyRegistrartionOptions)
       -- | The server provides workspace symbol support.
     , _workspaceSymbolProvider          :: Maybe Bool
       -- | Workspace specific server capabilities
     , _workspace                        :: Maybe WorkspaceServerCapabilities
-    , _callHierarchyProvider            :: Maybe (Bool |? CallHierarchyOptions |? CallHierarchyRegistrartionOptions)
       -- | Experimental server capabilities.
     , _experimental                     :: Maybe Value
     } deriving (Show, Read, Eq)

--- a/lsp-types/src/Language/LSP/Types/ServerCapabilities.hs
+++ b/lsp-types/src/Language/LSP/Types/ServerCapabilities.hs
@@ -7,6 +7,7 @@ module Language.LSP.Types.ServerCapabilities where
 import Data.Aeson
 import Data.Aeson.TH
 import Data.Text (Text)
+import Language.LSP.Types.CallHierarchy
 import Language.LSP.Types.CodeAction
 import Language.LSP.Types.CodeLens
 import Language.LSP.Types.Command
@@ -72,7 +73,7 @@ data ServerCapabilities =
       -- | The server provides signature help support.
     , _signatureHelpProvider            :: Maybe SignatureHelpOptions
       -- | The server provides go to declaration support.
-      -- 
+      --
       -- Since LSP 3.14.0
     , _declarationProvider              :: Maybe (Bool |? DeclarationOptions |? DeclarationRegistrationOptions)
       -- | The server provides goto definition support.
@@ -121,6 +122,7 @@ data ServerCapabilities =
     , _workspaceSymbolProvider          :: Maybe Bool
       -- | Workspace specific server capabilities
     , _workspace                        :: Maybe WorkspaceServerCapabilities
+    , _callHierarchyProvider            :: Maybe (Bool |? CallHierarchyOptions |? CallHierarchyRegistrartionOptions)
       -- | Experimental server capabilities.
     , _experimental                     :: Maybe Value
     } deriving (Show, Read, Eq)

--- a/lsp-types/src/Language/LSP/Types/ServerCapabilities.hs
+++ b/lsp-types/src/Language/LSP/Types/ServerCapabilities.hs
@@ -119,7 +119,7 @@ data ServerCapabilities =
       -- | The server provides selection range support. Since LSP 3.15
     , _selectionRangeProvider           :: Maybe (Bool |? SelectionRangeOptions |? SelectionRangeRegistrationOptions)
       -- | The server provides call hierarchy support.
-    , _callHierarchyProvider            :: Maybe (Bool |? CallHierarchyOptions |? CallHierarchyRegistrartionOptions)
+    , _callHierarchyProvider            :: Maybe (Bool |? CallHierarchyOptions |? CallHierarchyRegistrationOptions)
       -- | The server provides workspace symbol support.
     , _workspaceSymbolProvider          :: Maybe Bool
       -- | Workspace specific server capabilities

--- a/lsp/src/Language/LSP/Server/Core.hs
+++ b/lsp/src/Language/LSP/Server/Core.hs
@@ -535,35 +535,36 @@ registerCapability method regOpts f = do
 
     -- | Checks if client capabilities declares that the method supports dynamic registration
     dynamicSupported clientCaps = case method of
-      SWorkspaceDidChangeConfiguration -> capDyn $ clientCaps ^? J.workspace . _Just . J.didChangeConfiguration . _Just
-      SWorkspaceDidChangeWatchedFiles  -> capDyn $ clientCaps ^? J.workspace . _Just . J.didChangeWatchedFiles . _Just
-      SWorkspaceSymbol                 -> capDyn $ clientCaps ^? J.workspace . _Just . J.symbol . _Just
-      SWorkspaceExecuteCommand         -> capDyn $ clientCaps ^? J.workspace . _Just . J.executeCommand . _Just
-      STextDocumentDidOpen             -> capDyn $ clientCaps ^? J.textDocument . _Just . J.synchronization . _Just
-      STextDocumentDidChange           -> capDyn $ clientCaps ^? J.textDocument . _Just . J.synchronization . _Just
-      STextDocumentDidClose            -> capDyn $ clientCaps ^? J.textDocument . _Just . J.synchronization . _Just
-      STextDocumentCompletion          -> capDyn $ clientCaps ^? J.textDocument . _Just . J.completion . _Just
-      STextDocumentHover               -> capDyn $ clientCaps ^? J.textDocument . _Just . J.hover . _Just
-      STextDocumentSignatureHelp       -> capDyn $ clientCaps ^? J.textDocument . _Just . J.signatureHelp . _Just
-      STextDocumentDeclaration         -> capDyn $ clientCaps ^? J.textDocument . _Just . J.declaration . _Just
-      STextDocumentDefinition          -> capDyn $ clientCaps ^? J.textDocument . _Just . J.definition . _Just
-      STextDocumentTypeDefinition      -> capDyn $ clientCaps ^? J.textDocument . _Just . J.typeDefinition . _Just
-      STextDocumentImplementation      -> capDyn $ clientCaps ^? J.textDocument . _Just . J.implementation . _Just
-      STextDocumentReferences          -> capDyn $ clientCaps ^? J.textDocument . _Just . J.references . _Just
-      STextDocumentDocumentHighlight   -> capDyn $ clientCaps ^? J.textDocument . _Just . J.documentHighlight . _Just
-      STextDocumentDocumentSymbol      -> capDyn $ clientCaps ^? J.textDocument . _Just . J.documentSymbol . _Just
-      STextDocumentCodeAction          -> capDyn $ clientCaps ^? J.textDocument . _Just . J.codeAction . _Just
-      STextDocumentCodeLens            -> capDyn $ clientCaps ^? J.textDocument . _Just . J.codeLens . _Just
-      STextDocumentDocumentLink        -> capDyn $ clientCaps ^? J.textDocument . _Just . J.documentLink . _Just
-      STextDocumentDocumentColor       -> capDyn $ clientCaps ^? J.textDocument . _Just . J.colorProvider . _Just
-      STextDocumentColorPresentation   -> capDyn $ clientCaps ^? J.textDocument . _Just . J.colorProvider . _Just
-      STextDocumentFormatting          -> capDyn $ clientCaps ^? J.textDocument . _Just . J.formatting . _Just
-      STextDocumentRangeFormatting     -> capDyn $ clientCaps ^? J.textDocument . _Just . J.rangeFormatting . _Just
-      STextDocumentOnTypeFormatting    -> capDyn $ clientCaps ^? J.textDocument . _Just . J.onTypeFormatting . _Just
-      STextDocumentRename              -> capDyn $ clientCaps ^? J.textDocument . _Just . J.rename . _Just
-      STextDocumentFoldingRange        -> capDyn $ clientCaps ^? J.textDocument . _Just . J.foldingRange . _Just
-      STextDocumentSelectionRange      -> capDyn $ clientCaps ^? J.textDocument . _Just . J.selectionRange . _Just
-      _                                -> False
+      SWorkspaceDidChangeConfiguration  -> capDyn $ clientCaps ^? J.workspace . _Just . J.didChangeConfiguration . _Just
+      SWorkspaceDidChangeWatchedFiles   -> capDyn $ clientCaps ^? J.workspace . _Just . J.didChangeWatchedFiles . _Just
+      SWorkspaceSymbol                  -> capDyn $ clientCaps ^? J.workspace . _Just . J.symbol . _Just
+      SWorkspaceExecuteCommand          -> capDyn $ clientCaps ^? J.workspace . _Just . J.executeCommand . _Just
+      STextDocumentDidOpen              -> capDyn $ clientCaps ^? J.textDocument . _Just . J.synchronization . _Just
+      STextDocumentDidChange            -> capDyn $ clientCaps ^? J.textDocument . _Just . J.synchronization . _Just
+      STextDocumentDidClose             -> capDyn $ clientCaps ^? J.textDocument . _Just . J.synchronization . _Just
+      STextDocumentCompletion           -> capDyn $ clientCaps ^? J.textDocument . _Just . J.completion . _Just
+      STextDocumentHover                -> capDyn $ clientCaps ^? J.textDocument . _Just . J.hover . _Just
+      STextDocumentSignatureHelp        -> capDyn $ clientCaps ^? J.textDocument . _Just . J.signatureHelp . _Just
+      STextDocumentDeclaration          -> capDyn $ clientCaps ^? J.textDocument . _Just . J.declaration . _Just
+      STextDocumentDefinition           -> capDyn $ clientCaps ^? J.textDocument . _Just . J.definition . _Just
+      STextDocumentTypeDefinition       -> capDyn $ clientCaps ^? J.textDocument . _Just . J.typeDefinition . _Just
+      STextDocumentImplementation       -> capDyn $ clientCaps ^? J.textDocument . _Just . J.implementation . _Just
+      STextDocumentReferences           -> capDyn $ clientCaps ^? J.textDocument . _Just . J.references . _Just
+      STextDocumentDocumentHighlight    -> capDyn $ clientCaps ^? J.textDocument . _Just . J.documentHighlight . _Just
+      STextDocumentDocumentSymbol       -> capDyn $ clientCaps ^? J.textDocument . _Just . J.documentSymbol . _Just
+      STextDocumentCodeAction           -> capDyn $ clientCaps ^? J.textDocument . _Just . J.codeAction . _Just
+      STextDocumentCodeLens             -> capDyn $ clientCaps ^? J.textDocument . _Just . J.codeLens . _Just
+      STextDocumentDocumentLink         -> capDyn $ clientCaps ^? J.textDocument . _Just . J.documentLink . _Just
+      STextDocumentDocumentColor        -> capDyn $ clientCaps ^? J.textDocument . _Just . J.colorProvider . _Just
+      STextDocumentColorPresentation    -> capDyn $ clientCaps ^? J.textDocument . _Just . J.colorProvider . _Just
+      STextDocumentFormatting           -> capDyn $ clientCaps ^? J.textDocument . _Just . J.formatting . _Just
+      STextDocumentRangeFormatting      -> capDyn $ clientCaps ^? J.textDocument . _Just . J.rangeFormatting . _Just
+      STextDocumentOnTypeFormatting     -> capDyn $ clientCaps ^? J.textDocument . _Just . J.onTypeFormatting . _Just
+      STextDocumentRename               -> capDyn $ clientCaps ^? J.textDocument . _Just . J.rename . _Just
+      STextDocumentFoldingRange         -> capDyn $ clientCaps ^? J.textDocument . _Just . J.foldingRange . _Just
+      STextDocumentSelectionRange       -> capDyn $ clientCaps ^? J.textDocument . _Just . J.selectionRange . _Just
+      STextDocumentPrepareCallHierarchy -> capDyn $ clientCaps ^? J.textDocument . _Just . J.callHierarchy . _Just
+      _                                 -> False
 
 -- | Sends a @client/unregisterCapability@ request and removes the handler
 -- for that associated registration.

--- a/lsp/src/Language/LSP/Server/Processing.hs
+++ b/lsp/src/Language/LSP/Server/Processing.hs
@@ -163,6 +163,7 @@ inferServerCapabilities clientCaps o h =
     , _foldingRangeProvider             = supportedBool STextDocumentFoldingRange
     , _executeCommandProvider           = executeCommandProvider
     , _selectionRangeProvider           = supportedBool STextDocumentSelectionRange
+    , _callHierarchyProvider            = supportedBool STextDocumentPrepareCallHierarchy
     , _workspaceSymbolProvider          = supported SWorkspaceSymbol
     , _workspace                        = Just workspace
     -- TODO: Add something for experimental

--- a/lsp/test/MethodSpec.hs
+++ b/lsp/test/MethodSpec.hs
@@ -56,6 +56,9 @@ clientMethods = [
   ,"documentLink/resolve"
   ,"textDocument/rename"
   ,"textDocument/prepareRename"
+  ,"textDocument/prepareCallHierarchy"
+  ,"callHierarchy/incomingCalls"
+  ,"callHierarchy/outgoingCalls"
   ]
 
 serverMethods :: [T.Text]


### PR DESCRIPTION
As part of my GSoC 2021 works, this pr adds call hierarchy supporting according to [lsp spec](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_prepareCallHierarchy).