### PR TITLE
pass the lspConfig at initialization time as well

### DIFF
--- a/lsp-test/src/Language/LSP/Test.hs
+++ b/lsp-test/src/Language/LSP/Test.hs
@@ -199,7 +199,7 @@ runSessionWithHandles' serverProc serverIn serverOut config' caps rootDir sessio
                                           (Just lspTestClientInfo)
                                           (Just $ T.pack absRootDir)
                                           (Just $ filePathToUri absRootDir)
-                                          Nothing
+                                          (lspConfig config')
                                           caps
                                           (Just TraceOff)
                                           (List <$> initialWorkspaceFolders config)


### PR DESCRIPTION
This is needed in the ghcide benchmark suite because some of the Config options are not dynamic (`checkParents` is the one I am trying to change) and need to be given at initialisation 