### PR TITLE
Hashcons NormalizedFilePath values for efficient heap usage

### DIFF
--- a/lsp-types/lsp-types.cabal
+++ b/lsp-types/lsp-types.cabal
@@ -82,7 +82,6 @@ library
                      , hslogger
                      , lens >= 4.15.2
                      , network-uri
-                     , MemoTrie
                      , rope-utf16-splay >= 0.3.1.0
                      , scientific
                      , some

--- a/lsp-types/lsp-types.cabal
+++ b/lsp-types/lsp-types.cabal
@@ -82,6 +82,7 @@ library
                      , hslogger
                      , lens >= 4.15.2
                      , network-uri
+                     , MemoTrie
                      , rope-utf16-splay >= 0.3.1.0
                      , scientific
                      , some

--- a/lsp-types/src/Language/LSP/Types/Uri.hs
+++ b/lsp-types/src/Language/LSP/Types/Uri.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -23,17 +24,20 @@ import           Control.DeepSeq
 import qualified Data.Aeson                                 as A
 import           Data.Binary                                (Binary, Get, put, get)
 import           Data.Hashable
+import qualified Data.HashMap.Strict as HM
+import           Data.IORef                                (atomicModifyIORef', newIORef)
 import           Data.List                                  (stripPrefix)
-import           Data.MemoTrie                              (memo)
 import           Data.String                                (IsString, fromString)
 import           Data.Text                                  (Text)
 import qualified Data.Text                                  as T
+import           Data.Tuple                                (swap)
 import           GHC.Generics
 import           Network.URI hiding (authority)
 import qualified System.FilePath                            as FP
 import qualified System.FilePath.Posix                      as FPP
 import qualified System.FilePath.Windows                    as FPW
 import qualified System.Info
+import           System.IO.Unsafe                          (unsafePerformIO)
 
 newtype Uri = Uri { getUri :: Text }
   deriving (Eq,Ord,Read,Show,Generic,A.FromJSON,A.ToJSON,Hashable,A.ToJSONKey,A.FromJSONKey)
@@ -166,7 +170,7 @@ instance Binary NormalizedFilePath where
   get = do
     v <- Data.Binary.get :: Get FilePath
     let nuri = internalNormalizedFilePathToUri v
-    return (NormalizedFilePath nuri v)
+    return (intern $ NormalizedFilePath nuri v)
 
 -- | Internal helper that takes a file path that is assumed to
 -- already be normalized to a URI. It is up to the caller
@@ -189,13 +193,10 @@ instance IsString NormalizedFilePath where
     fromString = toNormalizedFilePath
 
 toNormalizedFilePath :: FilePath -> NormalizedFilePath
-toNormalizedFilePath fp = NormalizedFilePath nuri nfp
+toNormalizedFilePath fp = intern $ NormalizedFilePath nuri nfp
   where
-      nfp = internFilePath $ FP.normalise fp
+      nfp = FP.normalise fp
       nuri = internalNormalizedFilePathToUri nfp
-
-internFilePath :: FilePath -> FilePath
-internFilePath = force . memo FP.joinPath . FP.splitPath
 
 fromNormalizedFilePath :: NormalizedFilePath -> FilePath
 fromNormalizedFilePath (NormalizedFilePath _ fp) = fp
@@ -204,5 +205,20 @@ normalizedFilePathToUri :: NormalizedFilePath -> NormalizedUri
 normalizedFilePathToUri (NormalizedFilePath uri _) = uri
 
 uriToNormalizedFilePath :: NormalizedUri -> Maybe NormalizedFilePath
-uriToNormalizedFilePath nuri = fmap (NormalizedFilePath nuri . internFilePath) mbFilePath
+uriToNormalizedFilePath nuri = fmap (intern . NormalizedFilePath nuri) mbFilePath
   where mbFilePath = platformAwareUriToFilePath System.Info.os (fromNormalizedUri nuri)
+
+---------------------------------------------------------------------------
+-- Unsafe hashcons of NFP
+internIO :: (Eq a, Hashable a) => IO (a -> IO a)
+internIO = do
+    tableRef <- newIORef mempty
+    let f x = atomicModifyIORef' tableRef $ swap . flip HM.alterF x (\case
+         Just res -> (res, Just res)
+         Nothing  -> (x, Just x)
+         )
+    return f
+
+{-# NOINLINE intern #-}
+intern :: NormalizedFilePath -> NormalizedFilePath
+intern = let f = unsafePerformIO internIO in \x -> unsafePerformIO (f x)

--- a/lsp-types/src/Language/LSP/Types/Uri.hs
+++ b/lsp-types/src/Language/LSP/Types/Uri.hs
@@ -24,6 +24,7 @@ import qualified Data.Aeson                                 as A
 import           Data.Binary                                (Binary, Get, put, get)
 import           Data.Hashable
 import           Data.List                                  (stripPrefix)
+import           Data.MemoTrie                              (memo)
 import           Data.String                                (IsString, fromString)
 import           Data.Text                                  (Text)
 import qualified Data.Text                                  as T
@@ -33,7 +34,6 @@ import qualified System.FilePath                            as FP
 import qualified System.FilePath.Posix                      as FPP
 import qualified System.FilePath.Windows                    as FPW
 import qualified System.Info
-import Data.MemoTrie (memo)
 
 newtype Uri = Uri { getUri :: Text }
   deriving (Eq,Ord,Read,Show,Generic,A.FromJSON,A.ToJSON,Hashable,A.ToJSONKey,A.FromJSONKey)

--- a/lsp-types/src/Language/LSP/Types/Uri.hs
+++ b/lsp-types/src/Language/LSP/Types/Uri.hs
@@ -195,7 +195,7 @@ toNormalizedFilePath fp = NormalizedFilePath nuri nfp
       nuri = internalNormalizedFilePathToUri nfp
 
 internFilePath :: FilePath -> FilePath
-internFilePath = memo FP.joinPath . FP.splitPath
+internFilePath = force . memo FP.joinPath . FP.splitPath
 
 fromNormalizedFilePath :: NormalizedFilePath -> FilePath
 fromNormalizedFilePath (NormalizedFilePath _ fp) = fp

--- a/lsp-types/src/Language/LSP/Types/Uri.hs
+++ b/lsp-types/src/Language/LSP/Types/Uri.hs
@@ -9,7 +9,7 @@ module Language.LSP.Types.Uri
   , NormalizedUri(..)
   , toNormalizedUri
   , fromNormalizedUri
-  , NormalizedFilePath(..)
+  , NormalizedFilePath
   , toNormalizedFilePath
   , fromNormalizedFilePath
   , normalizedFilePathToUri

--- a/lsp-types/src/Language/LSP/Types/Uri.hs
+++ b/lsp-types/src/Language/LSP/Types/Uri.hs
@@ -170,7 +170,11 @@ instance Binary NormalizedFilePath where
   get = do
     v <- Data.Binary.get :: Get FilePath
     let nuri = internalNormalizedFilePathToUri v
-    return (intern $ NormalizedFilePath nuri v)
+    return (normalizedFilePath nuri v)
+
+-- | A smart constructor that performs UTF-8 encoding and hash consing
+normalizedFilePath :: NormalizedUri -> FilePath -> NormalizedFilePath
+normalizedFilePath nuri nfp = intern $ NormalizedFilePath nuri nfp
 
 -- | Internal helper that takes a file path that is assumed to
 -- already be normalized to a URI. It is up to the caller
@@ -193,7 +197,7 @@ instance IsString NormalizedFilePath where
     fromString = toNormalizedFilePath
 
 toNormalizedFilePath :: FilePath -> NormalizedFilePath
-toNormalizedFilePath fp = intern $ NormalizedFilePath nuri nfp
+toNormalizedFilePath fp = normalizedFilePath nuri nfp
   where
       nfp = FP.normalise fp
       nuri = internalNormalizedFilePathToUri nfp
@@ -205,7 +209,7 @@ normalizedFilePathToUri :: NormalizedFilePath -> NormalizedUri
 normalizedFilePathToUri (NormalizedFilePath uri _) = uri
 
 uriToNormalizedFilePath :: NormalizedUri -> Maybe NormalizedFilePath
-uriToNormalizedFilePath nuri = fmap (intern . NormalizedFilePath nuri) mbFilePath
+uriToNormalizedFilePath nuri = fmap (normalizedFilePath nuri) mbFilePath
   where mbFilePath = platformAwareUriToFilePath System.Info.os (fromNormalizedUri nuri)
 
 ---------------------------------------------------------------------------


### PR DESCRIPTION
`NormalizedFilePath` is one of the biggest costs in terms of heap space. The solution adopted here relies on the `MemoTrie` package to create a global trie of normalised file paths. The trie is branched by dir name and not by character, which hopefully leads to a more compact representation. 

The profiles below have been collected using an Edit experiment on a synthetic repo containing 300 empty modules with maximal imports, (every module imports all the modules below it).

## BEFORE

<img width="1401" alt="image" src="https://user-images.githubusercontent.com/26626/123125612-8e942100-d440-11eb-9b23-278d52387d6e.png">

## AFTER

<img width="1433" alt="image" src="https://user-images.githubusercontent.com/26626/123125654-9bb11000-d440-11eb-8138-26959a8e75b1.png">


