### PR TITLE
Expose NormalizedFilePath smart constructor

### DIFF
--- a/lsp-test/lsp-test.cabal
+++ b/lsp-test/lsp-test.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                lsp-test
-version:             0.14.0.0
+version:             0.14.0.1
 synopsis:            Functional test framework for LSP servers.
 description:
   A test framework for writing tests against
@@ -36,7 +36,7 @@ library
                      , parser-combinators:Control.Applicative.Combinators
   default-language:    Haskell2010
   build-depends:       base >= 4.10 && < 5
-                     , lsp-types == 1.2.*
+                     , lsp-types == 1.3.*
                      , aeson
                      , time
                      , aeson-pretty

--- a/lsp-types/lsp-types.cabal
+++ b/lsp-types/lsp-types.cabal
@@ -1,5 +1,5 @@
 name:                lsp-types
-version:             1.2.0.0
+version:             1.3.0.0
 synopsis:            Haskell library for the Microsoft Language Server Protocol, data types
 
 description:         An implementation of the types to allow language implementors to

--- a/lsp-types/src/Language/LSP/Types/Uri.hs
+++ b/lsp-types/src/Language/LSP/Types/Uri.hs
@@ -10,6 +10,7 @@ module Language.LSP.Types.Uri
   , toNormalizedUri
   , fromNormalizedUri
   , NormalizedFilePath
+  , normalizedFilePath
   , toNormalizedFilePath
   , fromNormalizedFilePath
   , normalizedFilePathToUri

--- a/lsp/lsp.cabal
+++ b/lsp/lsp.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                lsp
-version:             1.2.0.0
+version:             1.2.0.1
 synopsis:            Haskell library for the Microsoft Language Server Protocol
 
 description:         An implementation of the types, and basic message server to
@@ -41,7 +41,7 @@ library
                      , exceptions
                      , hslogger
                      , hashable
-                     , lsp-types == 1.2.*
+                     , lsp-types == 1.3.*
                      , dependent-map
                      , lens >= 4.15.2
                      , mtl


### PR DESCRIPTION
Forgot to expose this in #340 

I took the chance to bump version numbers as well, in order to facilitate the migration in HLS