### PR TITLE
Add compatibility with GHC 9.2

### DIFF
--- a/lsp-types/src/Language/LSP/Types/Utils.hs
+++ b/lsp-types/src/Language/LSP/Types/Utils.hs
@@ -38,7 +38,7 @@ instance FromJSON (SMethod $method) where
 makeInst :: Name -> Con -> Q [Dec]
 makeInst wrap (GadtC [sConstructor] args t) = do
   ns <- replicateM (length args) (newName "x")
-  let wrappedPat = pure $ ConP   wrap [ConP sConstructor  (map VarP ns)]
+  let wrappedPat = conP wrap [conP sConstructor (map varP ns)]
       unwrappedE = pure $ foldl' AppE (ConE sConstructor) (map VarE ns)
   [d| instance FromJSON $(pure t) where
         parseJSON = parseJSON >=> \case


### PR DESCRIPTION
`ConP` has a new field. To avoid the usage of CPP, prefer the smart constructor `conP` which seems to be backwards compatible.

Note, that `lsp` only compiles with `head.hackage` right now, so this PR is hard to test locally. 