### PR TITLE
Add dependen-sum lower version to fix build without cabal.project

### DIFF
--- a/lsp-types/lsp-types.cabal
+++ b/lsp-types/lsp-types.cabal
@@ -89,7 +89,9 @@ library
                      , rope-utf16-splay >= 0.3.1.0
                      , scientific
                      , some
-                     , dependent-sum-template
+                     , dependent-sum-template >= 0.1.0.0
+                     -- transitive dependency of the previous one, which does not have the correct lower bound
+                     , dependent-sum >= 0.7.1.0
                      , text
                      , template-haskell
                      , temporary


### PR DESCRIPTION
* F.e. the hackage ci build
* Fixes #349 