### PR TITLE
Sync lsp-types.cabal cabal-version with lsp.cabal

### DIFF
--- a/lsp-types/lsp-types.cabal
+++ b/lsp-types/lsp-types.cabal
@@ -1,3 +1,4 @@
+cabal-version:       2.2
 name:                lsp-types
 version:             1.3.0.1
 synopsis:            Haskell library for the Microsoft Language Server Protocol, data types
@@ -14,7 +15,6 @@ copyright:           Alan Zimmerman, 2016-2021
 category:            Development
 build-type:          Simple
 extra-source-files:  ChangeLog.md, README.md
-cabal-version:       >=1.10
 
 library
   exposed-modules:     Language.LSP.Types


### PR DESCRIPTION
* For make both consistent and cause i guess that could be the reason lsp-types is not built for newer ghc's in the hackage matrix: https://matrix.hackage.haskell.org/#/package/lsp-types but lsp is https://matrix.hackage.haskell.org/#/package/lsp
