### PR TITLE
CodeActionKind: add helpers for comparing them hierarchically

### DIFF
--- a/lsp-types/src/Language/LSP/Types/Capabilities.hs
+++ b/lsp-types/src/Language/LSP/Types/Capabilities.hs
@@ -223,14 +223,7 @@ capsForVersion (LSPVersion maj min) = ClientCapabilities (Just w) (Just td) (Jus
           (since 3 16 (CodeActionResolveClientCapabilities (List [])))
           (since 3 16 True)
     caKs = CodeActionKindClientCapabilities
-              (List [ CodeActionQuickFix
-                    , CodeActionRefactor
-                    , CodeActionRefactorExtract
-                    , CodeActionRefactorInline
-                    , CodeActionRefactorRewrite
-                    , CodeActionSource
-                    , CodeActionSourceOrganizeImports
-                    ])
+              (List specCodeActionKinds)
 
     signatureHelpCapability =
       SignatureHelpClientCapabilities


### PR DESCRIPTION
As I promised I would add in https://github.com/haskell/haskell-language-server/pull/2146