### PR TITLE
Aeson 2 compatibility

### DIFF
--- a/lsp-types/src/Language/LSP/Types/Common.hs
+++ b/lsp-types/src/Language/LSP/Types/Common.hs
@@ -9,7 +9,6 @@ module Language.LSP.Types.Common where
 import Control.Applicative
 import Control.DeepSeq
 import Data.Aeson
-import qualified Data.HashMap.Strict as HashMap
 import GHC.Generics
 
 -- | A terser, isomorphic data type for 'Either', that does not get tagged when
@@ -55,5 +54,5 @@ instance ToJSON Empty where
   toJSON Empty = Null
 instance FromJSON Empty where
   parseJSON Null = pure Empty
-  parseJSON (Object o) | HashMap.null o = pure Empty
+  parseJSON (Object o) | o == mempty = pure Empty
   parseJSON _ = fail "expected 'null' or '{}'"

--- a/lsp-types/src/Language/LSP/Types/Message.hs
+++ b/lsp-types/src/Language/LSP/Types/Message.hs
@@ -55,12 +55,12 @@ import           Language.LSP.Types.WatchedFiles
 import           Language.LSP.Types.WorkspaceEdit
 import           Language.LSP.Types.WorkspaceFolders
 import           Language.LSP.Types.WorkspaceSymbol
-import qualified Data.HashMap.Strict as HM
 
 import Data.Kind
 import Data.Aeson
 import Data.Aeson.TH
 import Data.Text (Text)
+import Data.String
 import GHC.Generics
 
 -- ---------------------------------------------------------------------
@@ -274,8 +274,8 @@ deriving instance Show (MessageParams m) => Show (RequestMessage m)
 -- | Replace a missing field in an object with a null field, to simplify parsing
 -- This is a hack to allow other types than Maybe to work like Maybe in allowing the field to be missing.
 -- See also this issue: https://github.com/haskell/aeson/issues/646
-addNullField :: Text -> Value -> Value
-addNullField s (Object o) = Object $ HM.insertWith (\_new old -> old) s Null o
+addNullField :: String -> Value -> Value
+addNullField s (Object o) = Object $ o <> fromString s .= Null
 addNullField _ v = v
 
 instance (FromJSON (MessageParams m), FromJSON (SMethod m)) => FromJSON (RequestMessage m) where

--- a/lsp/example/Reactor.hs
+++ b/lsp/example/Reactor.hs
@@ -30,7 +30,6 @@ import           Control.Monad
 import           Control.Monad.IO.Class
 import           Control.Monad.STM
 import qualified Data.Aeson                            as J
-import qualified Data.HashMap.Strict                   as H
 import qualified Data.Text                             as T
 import           GHC.Generics (Generic)
 import           Language.LSP.Server
@@ -263,8 +262,8 @@ handle = mconcat
               cmd = "lsp-hello-command"
               -- need 'file' and 'start_pos'
               args = J.List
-                      [ J.Object $ H.fromList [("file",     J.Object $ H.fromList [("textDocument",J.toJSON doc)])]
-                      , J.Object $ H.fromList [("start_pos",J.Object $ H.fromList [("position",    J.toJSON start)])]
+                      [ J.object [("file",     J.object [("textDocument",J.toJSON doc)])]
+                      , J.object [("start_pos",J.object [("position",    J.toJSON start)])]
                       ]
               cmdparams = Just args
           makeCommand (J.Diagnostic _r _s _c _source _m _t _l) = []


### PR DESCRIPTION
We get compatibility with both <2 and >=2 by using only functions that
appear in both, which don't make assumptions about the structure of
objects.

Fixes #356