### PR TITLE
Fix virtual file name adding .hs extension (rebased on master)

### DIFF
--- a/lsp-types/src/Language/LSP/VFS.hs
+++ b/lsp-types/src/Language/LSP/VFS.hs
@@ -41,7 +41,7 @@ module Language.LSP.VFS
   , changeChars
   ) where
 
-import           Control.Lens hiding ( parts )
+import           Control.Lens hiding ( (<.>), parts )
 import           Control.Monad
 import           Data.Char (isUpper, isAlphaNum)
 import           Data.Text ( Text )
@@ -247,7 +247,7 @@ virtualFileName prefix uri (VirtualFile _ file_ver _) =
       padLeft n num =
         let numString = show num
         in replicate (n - length numString) '0' ++ numString
-  in prefix </> basename ++ "-" ++ padLeft 5 file_ver ++ "-" ++ show (hash uri_raw) ++ ".hs"
+  in prefix </> basename ++ "-" ++ padLeft 5 file_ver ++ "-" ++ show (hash uri_raw) <.> takeExtensions basename
 
 -- | Write a virtual file to a temporary file if it exists in the VFS.
 persistFileVFS :: VFS -> J.NormalizedUri -> Maybe (FilePath, IO ())


### PR DESCRIPTION
#358 rebased on master

Problem: virtualFileName always adds a .hs extension to the filename.

Solution: Use takeExtensios instead to use the original file extension.