### PR TITLE
Fix extraneous `asdf` in `withProgress` output

### DIFF
--- a/lsp/src/Language/LSP/Server/Core.hs
+++ b/lsp/src/Language/LSP/Server/Core.hs
@@ -649,7 +649,6 @@ withProgressBase indefinite title cancellable f = do
 
   return res
   where updater progId (ProgressAmount percentage msg) = do
-          liftIO $ putStrLn "asdf"
           sendNotification SProgress $ fmap Report $ ProgressParams progId $
               WorkDoneProgressReportParams Nothing msg percentage
 


### PR DESCRIPTION
I was pretty surprised that after using `withProgress`, I started seeing in VS Code's `Log (Window)` the following output:

```
[2021-12-06 15:37:36.746] [renderer1] [error] Header must provide a Content-Length property.: Error: Header must provide a Content-Length property.
    at lo.onData (/home/heitor/.vscode/extensions/ligolang-publish.ligo-vscode-0.4.6/client/out/extension.js:2:14350)
    at Socket.<anonymous> (/home/heitor/.vscode/extensions/ligolang-publish.ligo-vscode-0.4.6/client/out/extension.js:2:14080)
    at Socket.emit (events.js:315:20)
    at addChunk (internal/streams/readable.js:309:12)
    at readableAddChunk (internal/streams/readable.js:284:9)
    at Socket.Readable.push (internal/streams/readable.js:223:10)
    at Pipe.onStreamRead (internal/stream_base_commons.js:188:23)
```

Taking a look at the code for `withProgress`, I noticed a weird `putStrLn "asdf"`. I removed this line locally and tested it once again and now `withProgress` was working as intended.

My guess is that `lsp` redirects control to `stdout` and this `asdf` string ended up being there, which caused VS Code to fail.