### PR TITLE
Eliminate dependent-sum-template dependency

### DIFF
--- a/lsp-types/lsp-types.cabal
+++ b/lsp-types/lsp-types.cabal
@@ -90,8 +90,6 @@ library
                      , rope-utf16-splay >= 0.3.1.0
                      , scientific
                      , some
-                     , dependent-sum-template >= 0.1.0.0
-                     -- transitive dependency of the previous one, which does not have the correct lower bound
                      , dependent-sum >= 0.7.1.0
                      , text
                      , template-haskell


### PR DESCRIPTION
Cf. https://github.com/haskell/lsp/pull/377#issuecomment-998869748

Eliminating `dependent-sum-template`, `th-extras` and `th-abstraction` should make builds more robust and provide a better experience when upgrading to new GHCs. 