### PR TITLE
Eliminate dependent-sum and dependent-map dependencies

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['9.0.1', '8.10.7', '8.8.4', '8.6.5']
+        ghc: ['9.2.1', '9.0.1', '8.10.7', '8.8.4', '8.6.5']
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/lsp-types/lsp-types.cabal
+++ b/lsp-types/lsp-types.cabal
@@ -20,6 +20,7 @@ library
   exposed-modules:     Language.LSP.Types
                      , Language.LSP.Types.Capabilities
                      , Language.LSP.Types.Lens
+                     , Language.LSP.Types.SMethodMap
                      , Language.LSP.VFS
                      , Data.IxMap
   other-modules:       Language.LSP.Types.CallHierarchy
@@ -90,7 +91,6 @@ library
                      , rope-utf16-splay >= 0.3.1.0
                      , scientific
                      , some
-                     , dependent-sum >= 0.7.1.0
                      , text
                      , template-haskell
                      , temporary

--- a/lsp/lsp.cabal
+++ b/lsp/lsp.cabal
@@ -42,7 +42,6 @@ library
                      , hslogger
                      , hashable
                      , lsp-types == 1.4.*
-                     , dependent-map
                      , lens >= 4.15.2
                      , mtl
                      , network-uri

--- a/lsp/src/Language/LSP/Server/Processing.hs
+++ b/lsp/src/Language/LSP/Server/Processing.hs
@@ -22,6 +22,8 @@ import qualified Data.Text.Lazy.Encoding as TL
 import Language.LSP.Types
 import Language.LSP.Types.Capabilities
 import qualified Language.LSP.Types.Lens as LSP
+import           Language.LSP.Types.SMethodMap (SMethodMap)
+import qualified Language.LSP.Types.SMethodMap as SMethodMap
 import Language.LSP.Server.Core
 import Language.LSP.VFS
 import Data.Functor.Product
@@ -34,9 +36,7 @@ import Control.Monad.Trans.Except
 import Control.Monad.Reader
 import Data.IxMap
 import System.Log.Logger
-import qualified Data.Dependent.Map as DMap
 import Data.Maybe
-import Data.Dependent.Map (DMap)
 import qualified Data.Map.Strict as Map
 import System.Exit
 import Data.Default (def)
@@ -185,8 +185,8 @@ inferServerCapabilities clientCaps o h =
 
     supported_b :: forall m. SClientMethod m -> Bool
     supported_b m = case splitClientMethod m of
-      IsClientNot -> DMap.member m $ notHandlers h
-      IsClientReq -> DMap.member m $ reqHandlers h
+      IsClientNot -> SMethodMap.member m $ notHandlers h
+      IsClientReq -> SMethodMap.member m $ reqHandlers h
       IsClientEither -> error "capabilities depend on custom method"
 
     singleton :: a -> [a]
@@ -335,8 +335,8 @@ handle' mAction m msg = do
   where
     -- | Checks to see if there's a dynamic handler, and uses it in favour of the
     -- static handler, if it exists.
-    pickHandler :: RegistrationMap t -> DMap SMethod (ClientMessageHandler IO t) -> Maybe (Handler IO m)
-    pickHandler dynHandlerMap staticHandler = case (DMap.lookup m dynHandlerMap, DMap.lookup m staticHandler) of
+    pickHandler :: RegistrationMap t -> SMethodMap (ClientMessageHandler IO t) -> Maybe (Handler IO m)
+    pickHandler dynHandlerMap staticHandler = case (SMethodMap.lookup m dynHandlerMap, SMethodMap.lookup m staticHandler) of
       (Just (Pair _ (ClientMessageHandler h)), _) -> Just h
       (Nothing, Just (ClientMessageHandler h)) -> Just h
       (Nothing, Nothing) -> Nothing


### PR DESCRIPTION
As discussed in https://github.com/haskell/lsp/pull/377#issuecomment-999452278

This removes `dependent-map`, `dependent-sum`, `constraints-extra` and `constraints` from dependencies and makes `lsp` buildable with GHC 9.2.