### PR TITLE
Remove CPP by using higher bound for the lsp test component

### DIFF
--- a/lsp/lsp.cabal
+++ b/lsp/lsp.cabal
@@ -112,7 +112,8 @@ test-suite unit-test
                        WorkspaceEditSpec
   build-depends:       base
                      , QuickCheck
-                     , aeson
+                     -- for instance Arbitrary Value
+                     , aeson >= 2.0.3.0
                      , containers
                      , filepath
                      , lsp

--- a/lsp/test/JsonSpec.hs
+++ b/lsp/test/JsonSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                  #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE TypeInType           #-}
@@ -159,16 +158,6 @@ smallList = resize 3 . listOf
 
 instance (Arbitrary a) => Arbitrary (List a) where
   arbitrary = List <$> arbitrary
-
-#if !MIN_VERSION_aeson(2,0,3)
-instance Arbitrary J.Value where
-  arbitrary = oneof
-    [ J.String <$> arbitrary
-    , J.Number <$> arbitrary
-    , J.Bool <$> arbitrary
-    , pure J.Null
-    ]
-#endif
 
 -- ---------------------------------------------------------------------
 


### PR DESCRIPTION
This gets us the instance that we need. Users who just depend on the
library component won't be affected by this and can continue to build
with any aeson version.