### PR TITLE
Change logging to use co-log-core instead of hslogger

### DIFF
--- a/lsp-test/bench/SimpleBench.hs
+++ b/lsp-test/bench/SimpleBench.hs
@@ -44,7 +44,7 @@ main = do
 
   n <- read . head <$> getArgs
 
-  forkIO $ void $ runServerWithHandles hinRead houtWrite server
+  forkIO $ void $ runServerWithHandles mempty mempty hinRead houtWrite server
   liftIO $ putStrLn $ "Starting " <> show n <> " rounds"
 
   i <- newIORef 0

--- a/lsp-test/lsp-test.cabal
+++ b/lsp-test/lsp-test.cabal
@@ -44,6 +44,7 @@ library
                      , ansi-terminal
                      , async
                      , bytestring
+                     , co-log-core
                      , conduit
                      , conduit-parse == 0.2.*
                      , containers >= 0.5.9
@@ -104,6 +105,7 @@ test-suite func-test
                      , lsp-test
                      , lsp
                      , process
+                     , co-log-core
                      , lens
                      , unliftio
                      , hspec

--- a/lsp-test/test/DummyServer.hs
+++ b/lsp-test/test/DummyServer.hs
@@ -35,7 +35,7 @@ withDummyServer f = do
         }
 
   bracket
-    (forkIO $ void $ runServerWithHandles hinRead houtWrite definition)
+    (forkIO $ void $ runServerWithHandles mempty mempty hinRead houtWrite definition)
     killThread
     (const $ f (hinWrite, houtRead))
 

--- a/lsp-types/src/Language/LSP/Types/Message.hs
+++ b/lsp-types/src/Language/LSP/Types/Message.hs
@@ -372,7 +372,7 @@ deriving instance Read (ResponseResult m) => Read (ResponseMessage m)
 deriving instance Show (ResponseResult m) => Show (ResponseMessage m)
 
 instance (ToJSON (ResponseResult m)) => ToJSON (ResponseMessage m) where
-  toJSON (ResponseMessage { _jsonrpc = jsonrpc, _id = lspid, _result = result })
+  toJSON ResponseMessage { _jsonrpc = jsonrpc, _id = lspid, _result = result }
     = object
       [ "jsonrpc" .= jsonrpc
       , "id" .= lspid
@@ -389,11 +389,11 @@ instance FromJSON (ResponseResult a) => FromJSON (ResponseMessage a) where
     _result  <- o .:! "result"
     _error   <- o .:? "error"
     result   <- case (_error, _result) of
-      ((Just err), Nothing   ) -> pure $ Left err
-      (Nothing   , (Just res)) -> pure $ Right res
-      ((Just _err), (Just _res)) -> fail $ "both error and result cannot be present: " ++ show o
+      (Just err, Nothing) -> pure $ Left err
+      (Nothing, Just res) -> pure $ Right res
+      (Just _err, Just _res) -> fail $ "both error and result cannot be present: " ++ show o
       (Nothing, Nothing) -> fail "both error and result cannot be Nothing"
-    return $ ResponseMessage _jsonrpc _id $ result
+    return $ ResponseMessage _jsonrpc _id result
 
 -- ---------------------------------------------------------------------
 -- Helper Type Families

--- a/lsp-types/src/Language/LSP/Types/Method.hs
+++ b/lsp-types/src/Language/LSP/Types/Method.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE TemplateHaskell            #-}
-{-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE MagicHash                  #-}
 {-# LANGUAGE TypeFamilies               #-}

--- a/lsp/ChangeLog.md
+++ b/lsp/ChangeLog.md
@@ -3,6 +3,7 @@
 ## 1.5.0.0
 
 * VFS module moved to `lsp` from `lsp-types`.
+* Logging reworked to use `co-log-core` instead of `hslogger`.
 
 ## 1.4.0.0
 

--- a/lsp/lsp.cabal
+++ b/lsp/lsp.cabal
@@ -26,6 +26,7 @@ library
                      , Language.LSP.Types.Lens
   exposed-modules:     Language.LSP.Server
                      , Language.LSP.Diagnostics
+                     , Language.LSP.Logging
                      , Language.LSP.VFS
   other-modules:       Language.LSP.Server.Core
                      , Language.LSP.Server.Control
@@ -37,16 +38,17 @@ library
                      , attoparsec
                      , bytestring
                      , containers
+                     , co-log-core >= 0.3.1.0
                      , data-default
                      , directory
                      , exceptions
                      , filepath
-                     , hslogger
                      , hashable
                      , lsp-types == 1.5.*
                      , lens >= 4.15.2
                      , mtl
                      , network-uri
+                     , prettyprinter
                      , sorted-list == 0.2.1.*
                      , stm == 2.5.*
                      , scientific
@@ -72,9 +74,10 @@ executable lsp-demo-reactor-server
 
   build-depends:       base 
                      , aeson
-                     , hslogger
+                     , co-log-core
                      , lens >= 4.15.2
                      , stm
+                     , prettyprinter
                      , text
                      -- the package library. Comment this out if you want repl changes to propagate
                      , lsp
@@ -133,7 +136,6 @@ test-suite unit-test
                      -- For GHCI tests
                      -- , async
                      -- , haskell-lsp-types
-                     -- , hslogger
                      -- , temporary
                      -- , time
                      -- , unordered-containers

--- a/lsp/src/Language/LSP/Logging.hs
+++ b/lsp/src/Language/LSP/Logging.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Language.LSP.Logging (logToShowMessage, logToLogMessage, defaultClientLogger) where
+
+import Colog.Core
+import Language.LSP.Server.Core
+import Language.LSP.Types
+import Data.Text (Text)
+
+logSeverityToMessageType :: Severity -> MessageType
+logSeverityToMessageType sev = case sev of
+  Error -> MtError
+  Warning -> MtWarning
+  Info -> MtInfo
+  Debug -> MtLog
+
+-- | Logs messages to the client via @window/logMessage@.
+logToLogMessage :: (MonadLsp c m) => LogAction m (WithSeverity Text)
+logToLogMessage = LogAction $ \(WithSeverity msg sev) -> do
+  sendToClient $ fromServerNot $
+    NotificationMessage "2.0" SWindowLogMessage (LogMessageParams (logSeverityToMessageType sev) msg)
+
+-- | Logs messages to the client via @window/showMessage@.
+logToShowMessage :: (MonadLsp c m) => LogAction m (WithSeverity Text)
+logToShowMessage = LogAction $ \(WithSeverity msg sev) -> do
+  sendToClient $ fromServerNot $
+    NotificationMessage "2.0" SWindowShowMessage (ShowMessageParams (logSeverityToMessageType sev) msg)
+
+-- | A 'sensible' log action for logging messages to the client:
+--
+--    * Shows 'Error' logs to the user via @window/showMessage@
+--    * Logs 'Info' and above logs in the client via @window/logMessage@
+--
+-- If you want finer control (e.g. the ability to log 'Debug' logs based on a flag, or similar),
+-- then do not use this and write your own based on 'logToShowMessage' and 'logToLogMessage'.
+defaultClientLogger :: (MonadLsp c m) => LogAction m (WithSeverity Text)
+defaultClientLogger =
+  filterBySeverity Error getSeverity logToShowMessage
+  <> filterBySeverity Info getSeverity logToLogMessage

--- a/lsp/src/Language/LSP/Server.hs
+++ b/lsp/src/Language/LSP/Server.hs
@@ -56,7 +56,6 @@ module Language.LSP.Server
   , unregisterCapability
   , RegistrationToken
 
-  , setupLogger
   , reverseSortEdit
   ) where
 

--- a/lsp/src/Language/LSP/Server/Control.hs
+++ b/lsp/src/Language/LSP/Server/Control.hs
@@ -1,7 +1,11 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE LambdaCase #-}
+
+-- So we can keep using the old prettyprinter modules (which have a better
+-- compatibility range) for now.
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module Language.LSP.Server.Control
   (
@@ -9,12 +13,16 @@ module Language.LSP.Server.Control
     runServer
   , runServerWith
   , runServerWithHandles
+  , LspServerLog (..)
   ) where
 
+import qualified Colog.Core as L
+import           Colog.Core (LogAction (..), WithSeverity (..), Severity (..), (<&))
 import           Control.Concurrent
 import           Control.Concurrent.STM.TChan
 import           Control.Monad
 import           Control.Monad.STM
+import           Control.Monad.IO.Class
 import qualified Data.Aeson as J
 import qualified Data.Attoparsec.ByteString as Attoparsec
 import Data.Attoparsec.ByteString.Char8
@@ -25,35 +33,78 @@ import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Encoding as TL
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
+import           Data.Text.Prettyprint.Doc
 import           Data.List
 import           Language.LSP.Server.Core
-import           Language.LSP.Server.Processing
+import qualified Language.LSP.Server.Processing as Processing
 import           Language.LSP.Types
 import           Language.LSP.VFS
+import Language.LSP.Logging (defaultClientLogger)
 import           System.IO
-import           System.Log.Logger
 
+data LspServerLog =
+  LspProcessingLog Processing.LspProcessingLog
+  | DecodeInitializeError String
+  | HeaderParseFail [String] String
+  | EOF
+  | Starting
+  | ParsedMsg T.Text
+  | SendMsg TL.Text
+  deriving (Show)
+
+instance Pretty LspServerLog where
+  pretty (LspProcessingLog l) = pretty l
+  pretty (DecodeInitializeError err) =
+    vsep [
+      "Got error while decoding initialize:"
+      , pretty err
+      ]
+  pretty (HeaderParseFail ctxs err) =
+    vsep [
+      "Failed to parse message header:"
+      , pretty (intercalate " > " ctxs) <> ": " <+> pretty err
+      ]
+  pretty EOF = "Got EOF"
+  pretty Starting = "Starting server"
+  pretty (ParsedMsg msg) = "---> " <> pretty msg
+  pretty (SendMsg msg) = "<--2-- " <> pretty msg
 
 -- ---------------------------------------------------------------------
 
--- | Convenience function for 'runServerWithHandles stdin stdout'.
-runServer :: ServerDefinition config
-                -- ^ function to be called once initialize has
-                -- been received from the client. Further message
-                -- processing will start only after this returns.
-    -> IO Int
-runServer = runServerWithHandles stdin stdout
+-- | Convenience function for 'runServerWithHandles' which:
+--     (1) reads from stdin;
+--     (2) writes to stdout; and
+--     (3) logs to stderr and to the client, with some basic filtering.
+runServer :: forall config . ServerDefinition config -> IO Int
+runServer =
+  runServerWithHandles
+  ioLogger
+  lspLogger
+  stdin
+  stdout
+  where
+    prettyMsg l = "[" <> viaShow (L.getSeverity l) <> "] " <> pretty (L.getMsg l)
+    ioLogger :: LogAction IO (WithSeverity LspServerLog)
+    ioLogger = L.cmap (show . prettyMsg) L.logStringStderr
+    lspLogger :: LogAction (LspM config) (WithSeverity LspServerLog)
+    lspLogger =
+      let clientLogger = L.cmap (fmap (T.pack . show . pretty)) defaultClientLogger
+      in clientLogger <> L.hoistLogAction liftIO ioLogger
 
--- | Starts a language server over the specified handles. 
+-- | Starts a language server over the specified handles.
 -- This function will return once the @exit@ notification is received.
 runServerWithHandles ::
-       Handle
+    LogAction IO (WithSeverity LspServerLog)
+    -- ^ The logger to use outside the main body of the server where we can't assume the ability to send messages.
+    -> LogAction (LspM config) (WithSeverity LspServerLog)
+    -- ^ The logger to use once the server has started and can successfully send messages.
+    -> Handle
     -- ^ Handle to read client input from.
     -> Handle
     -- ^ Handle to write output to.
     -> ServerDefinition config
     -> IO Int         -- exit code
-runServerWithHandles hin hout serverDefinition = do
+runServerWithHandles ioLogger logger hin hout serverDefinition = do
 
   hSetBuffering hin NoBuffering
   hSetEncoding  hin utf8
@@ -68,80 +119,70 @@ runServerWithHandles hin hout serverDefinition = do
       BSL.hPut hout out
       hFlush hout
 
-  runServerWith clientIn clientOut serverDefinition
+  runServerWith ioLogger logger clientIn clientOut serverDefinition
 
 -- | Starts listening and sending requests and responses
 -- using the specified I/O.
 runServerWith ::
-       IO BS.ByteString
+    LogAction IO (WithSeverity LspServerLog)
+    -- ^ The logger to use outside the main body of the server where we can't assume the ability to send messages.
+    -> LogAction (LspM config) (WithSeverity LspServerLog)
+    -- ^ The logger to use once the server has started and can successfully send messages.
+    -> IO BS.ByteString
     -- ^ Client input.
     -> (BSL.ByteString -> IO ())
     -- ^ Function to provide output to.
     -> ServerDefinition config
     -> IO Int         -- exit code
-runServerWith clientIn clientOut serverDefinition = do
+runServerWith ioLogger logger clientIn clientOut serverDefinition = do
 
-  infoM "lsp.runWith" "\n\n\n\n\nlsp:Starting up server ..."
+  ioLogger <& Starting `WithSeverity` Info
 
   cout <- atomically newTChan :: IO (TChan J.Value)
-  _rhpid <- forkIO $ sendServer cout clientOut
+  _rhpid <- forkIO $ sendServer ioLogger cout clientOut
 
   let sendMsg msg = atomically $ writeTChan cout $ J.toJSON msg
 
   initVFS $ \vfs -> do
-    ioLoop clientIn serverDefinition vfs sendMsg
+    ioLoop ioLogger logger clientIn serverDefinition vfs sendMsg
 
   return 1
 
 -- ---------------------------------------------------------------------
 
 ioLoop ::
-     IO BS.ByteString
+  forall config
+  .  LogAction IO (WithSeverity LspServerLog)
+  -> LogAction (LspM config) (WithSeverity LspServerLog)
+  -> IO BS.ByteString
   -> ServerDefinition config
   -> VFS
   -> (FromServerMessage -> IO ())
   -> IO ()
-ioLoop clientIn serverDefinition vfs sendMsg = do
-  minitialize <- parseOne (parse parser "")
+ioLoop ioLogger logger clientIn serverDefinition vfs sendMsg = do
+  minitialize <- parseOne ioLogger clientIn (parse parser "")
   case minitialize of
     Nothing -> pure ()
     Just (msg,remainder) -> do
       case J.eitherDecode $ BSL.fromStrict msg of
-        Left err ->
-          errorM "lsp.ioLoop" $
-            "Got error while decoding initialize:\n" <> err <> "\n exiting 1 ...\n"
+        Left err -> ioLogger <& DecodeInitializeError err `WithSeverity` Error
         Right initialize -> do
-          mInitResp <- initializeRequestHandler serverDefinition vfs sendMsg initialize
+          mInitResp <- Processing.initializeRequestHandler serverDefinition vfs sendMsg initialize
           case mInitResp of
             Nothing -> pure ()
-            Just env -> loop env (parse parser remainder)
+            Just env -> runLspT env $ loop (parse parser remainder)
   where
 
-    parseOne :: Result BS.ByteString -> IO (Maybe (BS.ByteString,BS.ByteString))
-    parseOne (Fail _ ctxs err) = do
-      errorM "lsp.parseOne" $
-        "Failed to parse message header:\n" <> intercalate " > " ctxs <> ": " <>
-        err <> "\n exiting 1 ...\n"
-      pure Nothing
-    parseOne (Partial c) = do
-      bs <- clientIn
-      if BS.null bs
-        then do
-          errorM "lsp.parseON" "lsp:Got EOF, exiting 1 ...\n"
-          pure Nothing
-        else parseOne (c bs)
-    parseOne (Done remainder msg) = do
-      debugM "lsp.parseOne" $ "---> " <> T.unpack (T.decodeUtf8 msg)
-      pure $ Just (msg,remainder)
-
-    loop env = go
+    loop :: Result BS.ByteString -> LspM config ()
+    loop = go
       where
+        pLogger =  L.cmap (fmap LspProcessingLog) logger
         go r = do
-          res <- parseOne r
+          res <- parseOne logger clientIn r
           case res of
             Nothing -> pure ()
             Just (msg,remainder) -> do
-              runLspT env $ processMessage $ BSL.fromStrict msg
+              Processing.processMessage pLogger $ BSL.fromStrict msg
               go (parse parser remainder)
 
     parser = do
@@ -150,11 +191,33 @@ ioLoop clientIn serverDefinition vfs sendMsg = do
       _ <- string _TWO_CRLF
       Attoparsec.take len
 
+parseOne ::
+  MonadIO m
+  => LogAction m (WithSeverity LspServerLog)
+  -> IO BS.ByteString
+  -> Result BS.ByteString
+  -> m (Maybe (BS.ByteString,BS.ByteString))
+parseOne logger clientIn = go
+  where
+    go (Fail _ ctxs err) = do
+      logger <& HeaderParseFail ctxs err `WithSeverity` Error
+      pure Nothing
+    go (Partial c) = do
+      bs <- liftIO clientIn
+      if BS.null bs
+        then do
+          logger <& EOF `WithSeverity` Error
+          pure Nothing
+        else go (c bs)
+    go (Done remainder msg) = do
+      logger <& ParsedMsg (T.decodeUtf8 msg) `WithSeverity` Debug
+      pure $ Just (msg,remainder)
+
 -- ---------------------------------------------------------------------
 
 -- | Simple server to make sure all output is serialised
-sendServer :: TChan J.Value -> (BSL.ByteString -> IO ()) -> IO ()
-sendServer msgChan clientOut = do
+sendServer :: LogAction IO (WithSeverity LspServerLog) -> TChan J.Value -> (BSL.ByteString -> IO ()) -> IO ()
+sendServer logger msgChan clientOut = do
   forever $ do
     msg <- atomically $ readTChan msgChan
 
@@ -168,7 +231,7 @@ sendServer msgChan clientOut = do
                 , str ]
 
     clientOut out
-    debugM "lsp.sendServer" $ "<--2--" <> TL.unpack (TL.decodeUtf8 str)
+    logger <& SendMsg (TL.decodeUtf8 str) `WithSeverity` Debug
 
 -- |
 --

--- a/lsp/src/Language/LSP/Server/Core.hs
+++ b/lsp/src/Language/LSP/Server/Core.hs
@@ -2,25 +2,16 @@
 {-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE BangPatterns         #-}
-{-# LANGUAGE LambdaCase           #-}
 {-# LANGUAGE GADTs                #-}
-{-# LANGUAGE MultiWayIf           #-}
 {-# LANGUAGE BinaryLiterals       #-}
 {-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE RankNTypes           #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
-{-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE ViewPatterns         #-}
 {-# LANGUAGE TypeInType           #-}
-{-# LANGUAGE TypeApplications     #-}
-{-# LANGUAGE RecordWildCards      #-}
-{-# LANGUAGE NamedFieldPuns       #-}
 {-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE RecursiveDo #-}
 {-# LANGUAGE RoleAnnotations #-}
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 {-# OPTIONS_GHC -fprint-explicit-kinds #-}
@@ -28,6 +19,7 @@
 
 module Language.LSP.Server.Core where
 
+import           Colog.Core (LogAction (..), WithSeverity (..))
 import           Control.Concurrent.Async
 import           Control.Concurrent.STM
 import qualified Control.Exception as E
@@ -37,7 +29,7 @@ import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Reader
 import           Control.Monad.Trans.Class
 import           Control.Monad.IO.Unlift
-import           Control.Lens ( (^.), (^?), _Just )
+import           Control.Lens ( (^.), (^?), _Just, at)
 import qualified Data.Aeson as J
 import           Data.Default
 import           Data.Functor.Product
@@ -59,12 +51,6 @@ import qualified Language.LSP.Types.SMethodMap as SMethodMap
 import qualified Language.LSP.Types.Lens as J
 import           Language.LSP.VFS
 import           Language.LSP.Diagnostics
-import           System.IO
-import qualified System.Log.Formatter as L
-import qualified System.Log.Handler as LH
-import qualified System.Log.Handler.Simple as LHS
-import           System.Log.Logger
-import qualified System.Log.Logger as L
 import           System.Random hiding (next)
 import           Control.Monad.Trans.Identity
 import           Control.Monad.Catch (MonadMask, MonadCatch, MonadThrow)
@@ -107,7 +93,7 @@ instance MonadLsp c m => MonadLsp c (IdentityT m) where
 data LanguageContextEnv config =
   LanguageContextEnv
   { resHandlers            :: !(Handlers IO)
-  , resParseConfig         :: !(config -> J.Value -> (Either T.Text config))
+  , resParseConfig         :: !(config -> J.Value -> Either T.Text config)
   , resSendMessage         :: !(FromServerMessage -> IO ())
   -- We keep the state in a TVar to be thread safe
   , resState               :: !(LanguageContextState config)
@@ -359,7 +345,7 @@ sendRequest m params resHandler = do
   reqId <- IdInt <$> freshLspId
   rio <- askRunInIO
   success <- addResponseHandler reqId (Pair m (ServerResponseCallback (rio . resHandler)))
-  unless success $ error "haskell-lsp: could not send FromServer request as id is reused"
+  unless success $ error "LSP: could not send FromServer request as id is reused"
 
   let msg = RequestMessage "2.0" reqId m params
   ~() <- case splitServerMethod m of
@@ -371,7 +357,9 @@ sendRequest m params resHandler = do
 
 -- | Return the 'VirtualFile' associated with a given 'NormalizedUri', if there is one.
 getVirtualFile :: MonadLsp config m => NormalizedUri -> m (Maybe VirtualFile)
-getVirtualFile uri = Map.lookup uri . vfsMap . vfsData <$> getsState resVFS
+getVirtualFile uri = do
+  dat <- vfsData <$> getsState resVFS
+  pure $ dat ^. vfsMap . at uri
 
 {-# INLINE getVirtualFile #-}
 
@@ -389,10 +377,10 @@ snapshotVirtualFiles env = vfsData <$> readTVar (resVFS $ resState env)
 
 -- | Dump the current text for a given VFS file to a temporary file,
 -- and return the path to the file.
-persistVirtualFile :: MonadLsp config m => NormalizedUri -> m (Maybe FilePath)
-persistVirtualFile uri = do
+persistVirtualFile :: MonadLsp config m => LogAction m (WithSeverity VfsLog) -> NormalizedUri -> m (Maybe FilePath)
+persistVirtualFile logger uri = do
   join $ stateState resVFS $ \vfs ->
-    case persistFileVFS (vfsData vfs) uri of
+    case persistFileVFS logger (vfsData vfs) uri of
       Nothing -> (return Nothing, vfs)
       Just (fn, write) ->
         let !revMap = case uriToFilePath (fromNormalizedUri uri) of
@@ -402,7 +390,7 @@ persistVirtualFile uri = do
               Nothing -> reverseMap vfs
             !vfs' = vfs {reverseMap = revMap}
             act = do
-              liftIO write
+              write
               pure (Just fn)
         in (act, vfs')
 
@@ -437,15 +425,6 @@ sendToClient msg = do
   liftIO $ f msg
 
 {-# INLINE sendToClient #-}
-
--- ---------------------------------------------------------------------
-
-sendErrorLog :: MonadLsp config m => Text -> m ()
-sendErrorLog msg =
-  sendToClient $ fromServerNot $
-    NotificationMessage "2.0" SWindowLogMessage (LogMessageParams MtError msg)
-
-{-# INLINE sendErrorLog #-}
 
 -- ---------------------------------------------------------------------
 
@@ -724,45 +703,6 @@ flushDiagnosticsBySource maxDiagnosticCount msource = join $ stateState resDiagn
           Just params -> do
             sendToClient $ J.fromServerNot $ J.NotificationMessage "2.0" J.STextDocumentPublishDiagnostics params
       in (act,newDiags)
-
--- =====================================================================
---
---  utility
-
-
---
---  Logger
---
-setupLogger :: Maybe FilePath -> [String] -> Priority -> IO ()
-setupLogger mLogFile extraLogNames level = do
-
-  logStream <- case mLogFile of
-    Just logFile -> openFile logFile AppendMode `E.catch` handleIOException logFile
-    Nothing      -> return stderr
-  hSetEncoding logStream utf8
-
-  logH <- LHS.streamHandler logStream level
-
-  let logHandle  = logH {LHS.closeFunc = hClose}
-      logFormatter  = L.tfLogFormatter logDateFormat logFormat
-      logHandler = LH.setFormatter logHandle logFormatter
-
-  L.updateGlobalLogger L.rootLoggerName $ L.setHandlers ([] :: [LHS.GenericHandler Handle])
-  L.updateGlobalLogger "haskell-lsp" $ L.setHandlers [logHandler]
-  L.updateGlobalLogger "haskell-lsp" $ L.setLevel level
-
-  -- Also route the additional log names to the same log
-  forM_ extraLogNames $ \logName -> do
-    L.updateGlobalLogger logName $ L.setHandlers [logHandler]
-    L.updateGlobalLogger logName $ L.setLevel level
-  where
-    logFormat = "$time [$tid] $prio $loggername:\t$msg"
-    logDateFormat = "%Y-%m-%d %H:%M:%S%Q"
-
-handleIOException :: FilePath -> E.IOException ->  IO Handle
-handleIOException logFile _ = do
-  hPutStr stderr $ "Couldn't open log file " ++ logFile ++ "; falling back to stderr logging"
-  return stderr
 
 -- ---------------------------------------------------------------------
 

--- a/lsp/src/Language/LSP/VFS.hs
+++ b/lsp/src/Language/LSP/VFS.hs
@@ -6,7 +6,16 @@
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE TypeInType #-}
+
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE FlexibleInstances #-}
+
+-- So we can keep using the old prettyprinter modules (which have a better
+-- compatibility range) for now.
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 {-|
 Handles the "Language.LSP.Types.TextDocumentDidChange" \/
@@ -18,9 +27,15 @@ files in the client workspace by operating on the "VFS" in "LspFuncs".
 module Language.LSP.VFS
   (
     VFS(..)
+  , vfsMap
+  , vfsTempDir
   , VirtualFile(..)
+  , lsp_version
+  , file_version
+  , file_text
   , virtualFileText
   , virtualFileVersion
+  , VfsLog (..)
   -- * Managing the VFS
   , initVFS
   , openVFS
@@ -28,7 +43,6 @@ module Language.LSP.VFS
   , changeFromServerVFS
   , persistFileVFS
   , closeVFS
-  , updateVFS
 
   -- * manipulating the file contents
   , rangeLinesFromVfs
@@ -43,9 +57,12 @@ module Language.LSP.VFS
 
 import           Control.Lens hiding ( (<.>), parts )
 import           Control.Monad
+import           Colog.Core (LogAction (..), WithSeverity (..), Severity (..), (<&))
+import           Control.Monad.State
 import           Data.Char (isUpper, isAlphaNum)
 import           Data.Text ( Text )
 import qualified Data.Text as T
+import qualified Data.Text.IO as T
 import           Data.Int (Int32)
 import           Data.List
 import           Data.Ord
@@ -54,14 +71,15 @@ import qualified Data.Map.Strict as Map
 import           Data.Maybe
 import           Data.Text.Utf16.Rope ( Rope )
 import qualified Data.Text.Utf16.Rope as Rope
+import           Data.Text.Prettyprint.Doc
 import qualified Language.LSP.Types           as J
 import qualified Language.LSP.Types.Lens      as J
 import           System.FilePath
 import           Data.Hashable
 import           System.Directory
-import           System.IO 
+import           System.IO
 import           System.IO.Temp
-import           System.Log.Logger
+import Data.Foldable (traverse_)
 
 -- ---------------------------------------------------------------------
 {-# ANN module ("hlint: ignore Eta reduce" :: String) #-}
@@ -73,20 +91,41 @@ data VirtualFile =
       _lsp_version :: !Int32  -- ^ The LSP version of the document
     , _file_version :: !Int -- ^ This number is only incremented whilst the file
                            -- remains in the map.
-    , _text    :: !Rope  -- ^ The full contents of the document
+    , _file_text    :: !Rope  -- ^ The full contents of the document
     } deriving (Show)
 
-
-type VFSMap = Map.Map J.NormalizedUri VirtualFile
-
-data VFS = VFS { vfsMap :: !(Map.Map J.NormalizedUri VirtualFile)
-               , vfsTempDir :: !FilePath -- ^ This is where all the temporary files will be written to
+data VFS = VFS { _vfsMap :: !(Map.Map J.NormalizedUri VirtualFile)
+               , _vfsTempDir :: !FilePath -- ^ This is where all the temporary files will be written to
                } deriving Show
+
+data VfsLog =
+  SplitInsideCodePoint Rope.Position Rope
+  | URINotFound J.NormalizedUri
+  | Opening J.NormalizedUri
+  | Closing J.NormalizedUri
+  | PersistingFile J.NormalizedUri FilePath
+  | CantRecursiveDelete J.NormalizedUri
+  | DeleteNonExistent J.NormalizedUri
+  deriving (Show)
+
+instance Pretty VfsLog where
+  pretty (SplitInsideCodePoint pos r) =
+    "VFS: asked to make change inside code point. Position" <+> viaShow pos <+> "in" <+> viaShow r
+  pretty (URINotFound uri) = "VFS: don't know about URI" <+> viaShow uri
+  pretty (Opening uri) = "VFS: opening" <+> viaShow uri
+  pretty (Closing uri) = "VFS: closing" <+> viaShow uri
+  pretty (PersistingFile uri fp) = "VFS: Writing virtual file for" <+> viaShow uri <+> "to" <+> viaShow fp
+  pretty (CantRecursiveDelete uri) =
+    "VFS: can't recursively delete" <+> viaShow uri <+> "because we don't track directory status"
+  pretty (DeleteNonExistent uri) = "VFS: asked to delete non-existent file" <+> viaShow uri
+
+makeFieldsNoPrefix ''VirtualFile
+makeFieldsNoPrefix ''VFS
 
 ---
 
 virtualFileText :: VirtualFile -> Text
-virtualFileText vf = Rope.toText (_text  vf)
+virtualFileText vf = Rope.toText (_file_text vf)
 
 virtualFileVersion :: VirtualFile -> Int32
 virtualFileVersion vf = _lsp_version vf
@@ -99,51 +138,44 @@ initVFS k = withSystemTempDirectory "haskell-lsp" $ \temp_dir -> k (VFS mempty t
 -- ---------------------------------------------------------------------
 
 -- | Applies the changes from a 'J.DidOpenTextDocument' to the 'VFS'
-openVFS :: VFS -> J.Message 'J.TextDocumentDidOpen -> (VFS, [String])
-openVFS vfs (J.NotificationMessage _ _ params) =
-  let J.DidOpenTextDocumentParams
-         (J.TextDocumentItem uri _ version text) = params
-  in (updateVFS (Map.insert (J.toNormalizedUri uri) (VirtualFile version 0 (Rope.fromText text))) vfs
-     , [])
-
+openVFS :: (MonadState VFS m) => LogAction m (WithSeverity VfsLog) -> J.Message 'J.TextDocumentDidOpen -> m ()
+openVFS logger msg = do
+  let J.TextDocumentItem (J.toNormalizedUri -> uri) _ version text = msg ^. J.params . J.textDocument
+      vfile = VirtualFile version 0 (Rope.fromText text)
+  logger <& Opening uri `WithSeverity` Debug
+  vfsMap . at uri .= Just vfile
 
 -- ---------------------------------------------------------------------
 
--- ^ Applies a 'DidChangeTextDocumentNotification' to the 'VFS'
-changeFromClientVFS :: VFS -> J.Message 'J.TextDocumentDidChange -> (VFS,[String])
-changeFromClientVFS vfs (J.NotificationMessage _ _ params) =
+-- | Applies a 'DidChangeTextDocumentNotification' to the 'VFS'
+changeFromClientVFS :: (MonadState VFS m) => LogAction m (WithSeverity VfsLog) -> J.Message 'J.TextDocumentDidChange -> m ()
+changeFromClientVFS logger msg = do
   let
-    J.DidChangeTextDocumentParams vid (J.List changes) = params
-    J.VersionedTextDocumentIdentifier (J.toNormalizedUri -> uri) version = vid
-  in
-    case Map.lookup uri (vfsMap vfs) of
-      Just (VirtualFile _ file_ver str) ->
-        let str' = applyChanges str changes
-        -- the client shouldn't be sending over a null version, only the server.
-        in (updateVFS (Map.insert uri (VirtualFile (fromMaybe 0 version) (file_ver + 1) str')) vfs, [])
-      Nothing ->
-        -- logs $ "haskell-lsp:changeVfs:can't find uri:" ++ show uri
-        -- return vfs
-        (vfs, ["haskell-lsp:changeVfs:can't find uri:" ++ show uri])
-
-updateVFS :: (VFSMap -> VFSMap) -> VFS -> VFS
-updateVFS f vfs@VFS{vfsMap} = vfs { vfsMap = f vfsMap }
+    J.DidChangeTextDocumentParams vid (J.List changes) = msg ^. J.params
+    -- the client shouldn't be sending over a null version, only the server, but we just use 0 if that happens
+    J.VersionedTextDocumentIdentifier (J.toNormalizedUri -> uri) (fromMaybe 0 -> version) = vid
+  vfs <- get
+  case vfs ^. vfsMap . at uri of
+    Just (VirtualFile _ file_ver contents) -> do
+      contents' <- applyChanges logger contents changes
+      vfsMap . at uri .= Just (VirtualFile version (file_ver + 1) contents')
+    Nothing -> logger <& URINotFound uri `WithSeverity` Warning
 
 -- ---------------------------------------------------------------------
 
-applyCreateFile :: J.CreateFile -> VFS -> VFS
-applyCreateFile (J.CreateFile uri options _ann) = 
-  updateVFS $ Map.insertWith 
+applyCreateFile :: (MonadState VFS m) => J.CreateFile -> m ()
+applyCreateFile (J.CreateFile (J.toNormalizedUri -> uri) options _ann) =
+  vfsMap %= Map.insertWith
                 (\ new old -> if shouldOverwrite then new else old)
-                (J.toNormalizedUri uri)
+                uri
                 (VirtualFile 0 0 mempty)
-  where 
-    shouldOverwrite :: Bool 
-    shouldOverwrite = case options of 
+  where
+    shouldOverwrite :: Bool
+    shouldOverwrite = case options of
         Nothing                                               -> False  -- default
         Just (J.CreateFileOptions Nothing       Nothing     ) -> False  -- default
-        Just (J.CreateFileOptions Nothing       (Just True) ) -> False  -- `ignoreIfExists` is True 
-        Just (J.CreateFileOptions Nothing       (Just False)) -> True   -- `ignoreIfExists` is False 
+        Just (J.CreateFileOptions Nothing       (Just True) ) -> False  -- `ignoreIfExists` is True
+        Just (J.CreateFileOptions Nothing       (Just False)) -> True   -- `ignoreIfExists` is False
         Just (J.CreateFileOptions (Just True)   Nothing     ) -> True   -- `overwrite` is True
         Just (J.CreateFileOptions (Just True)   (Just True) ) -> True   -- `overwrite` wins over `ignoreIfExists`
         Just (J.CreateFileOptions (Just True)   (Just False)) -> True   -- `overwrite` is True
@@ -151,26 +183,27 @@ applyCreateFile (J.CreateFile uri options _ann) =
         Just (J.CreateFileOptions (Just False)  (Just True) ) -> False  -- `overwrite` is False
         Just (J.CreateFileOptions (Just False)  (Just False)) -> False  -- `overwrite` wins over `ignoreIfExists`
 
-applyRenameFile :: J.RenameFile -> VFS -> VFS
-applyRenameFile (J.RenameFile oldUri' newUri' options _ann) vfs = 
-  let oldUri = J.toNormalizedUri oldUri'
-      newUri = J.toNormalizedUri newUri'
-  in  case Map.lookup oldUri (vfsMap vfs) of 
-        -- nothing to rename 
-        Nothing -> vfs 
-        Just file -> case Map.lookup newUri (vfsMap vfs) of 
-          -- the target does not exist, just move over 
-          Nothing -> updateVFS (Map.insert newUri file . Map.delete oldUri) vfs
-          Just _  -> if shouldOverwrite 
-                      then updateVFS (Map.insert newUri file . Map.delete oldUri) vfs
-                      else vfs 
-  where 
-    shouldOverwrite :: Bool 
-    shouldOverwrite = case options of 
+applyRenameFile :: (MonadState VFS m) => J.RenameFile -> m ()
+applyRenameFile (J.RenameFile (J.toNormalizedUri -> oldUri) (J.toNormalizedUri -> newUri) options _ann) = do
+  vfs <- get
+  case vfs ^. vfsMap . at oldUri of
+      -- nothing to rename
+      Nothing -> pure ()
+      Just file -> case vfs ^. vfsMap . at newUri of
+        -- the target does not exist, just move over
+        Nothing -> do
+          vfsMap . at oldUri .= Nothing
+          vfsMap . at newUri .= Just file
+        Just _  -> when shouldOverwrite $ do
+          vfsMap . at oldUri .= Nothing
+          vfsMap . at newUri .= Just file
+  where
+    shouldOverwrite :: Bool
+    shouldOverwrite = case options of
         Nothing                                               -> False  -- default
         Just (J.RenameFileOptions Nothing       Nothing     ) -> False  -- default
-        Just (J.RenameFileOptions Nothing       (Just True) ) -> False  -- `ignoreIfExists` is True 
-        Just (J.RenameFileOptions Nothing       (Just False)) -> True   -- `ignoreIfExists` is False 
+        Just (J.RenameFileOptions Nothing       (Just True) ) -> False  -- `ignoreIfExists` is True
+        Just (J.RenameFileOptions Nothing       (Just False)) -> True   -- `ignoreIfExists` is False
         Just (J.RenameFileOptions (Just True)   Nothing     ) -> True   -- `overwrite` is True
         Just (J.RenameFileOptions (Just True)   (Just True) ) -> True   -- `overwrite` wins over `ignoreIfExists`
         Just (J.RenameFileOptions (Just True)   (Just False)) -> True   -- `overwrite` is True
@@ -178,23 +211,29 @@ applyRenameFile (J.RenameFile oldUri' newUri' options _ann) vfs =
         Just (J.RenameFileOptions (Just False)  (Just True) ) -> False  -- `overwrite` is False
         Just (J.RenameFileOptions (Just False)  (Just False)) -> False  -- `overwrite` wins over `ignoreIfExists`
 
--- NOTE: we are ignoring the `recursive` option here because we don't know which file is a directory
-applyDeleteFile :: J.DeleteFile -> VFS -> VFS
-applyDeleteFile (J.DeleteFile uri _options _ann) = 
-  updateVFS $ Map.delete (J.toNormalizedUri uri)
+applyDeleteFile :: (MonadState VFS m) => LogAction m (WithSeverity VfsLog) -> J.DeleteFile -> m ()
+applyDeleteFile logger (J.DeleteFile (J.toNormalizedUri -> uri) options _ann) = do
+  -- NOTE: we are ignoring the `recursive` option here because we don't know which file is a directory
+  when (options ^? _Just . J.recursive . _Just == Just True) $
+    logger <& CantRecursiveDelete uri `WithSeverity` Warning
+  -- Remove and get the old value so we can check if it was missing
+  old <- vfsMap . at uri <.= Nothing
+  case old of
+    -- It's not entirely clear what the semantics of 'ignoreIfNotExists' are, but if it
+    -- doesn't exist and we're not ignoring it, let's at least log it.
+    Nothing | options ^? _Just . J.ignoreIfNotExists . _Just /= Just True ->
+              logger <& CantRecursiveDelete uri `WithSeverity` Warning
+    _ -> pure ()
 
-
-applyTextDocumentEdit :: J.TextDocumentEdit -> VFS -> IO VFS
-applyTextDocumentEdit (J.TextDocumentEdit vid (J.List edits)) vfs = do
+applyTextDocumentEdit :: (MonadState VFS m) => LogAction m (WithSeverity VfsLog) -> J.TextDocumentEdit -> m ()
+applyTextDocumentEdit logger (J.TextDocumentEdit vid (J.List edits)) = do
   -- all edits are supposed to be applied at once
   -- so apply from bottom up so they don't affect others
   let sortedEdits = sortOn (Down . editRange) edits
       changeEvents = map editToChangeEvent sortedEdits
       ps = J.DidChangeTextDocumentParams vid (J.List changeEvents)
       notif = J.NotificationMessage "" J.STextDocumentDidChange ps
-  let (vfs',ls) = changeFromClientVFS vfs notif
-  mapM_ (debugM "haskell-lsp.applyTextDocumentEdit") ls
-  return vfs'
+  changeFromClientVFS logger notif
 
   where
     editRange :: J.TextEdit J.|? J.AnnotatedTextEdit -> J.Range
@@ -205,32 +244,30 @@ applyTextDocumentEdit (J.TextDocumentEdit vid (J.List edits)) vfs = do
     editToChangeEvent (J.InR e) = J.TextDocumentContentChangeEvent (Just $ e ^. J.range) Nothing (e ^. J.newText)
     editToChangeEvent (J.InL e) = J.TextDocumentContentChangeEvent (Just $ e ^. J.range) Nothing (e ^. J.newText)
 
-applyDocumentChange :: J.DocumentChange -> VFS -> IO VFS 
-applyDocumentChange (J.InL               change)   = applyTextDocumentEdit change
-applyDocumentChange (J.InR (J.InL        change))  = return . applyCreateFile change
-applyDocumentChange (J.InR (J.InR (J.InL change))) = return . applyRenameFile change
-applyDocumentChange (J.InR (J.InR (J.InR change))) = return . applyDeleteFile change
+applyDocumentChange :: (MonadState VFS m) => LogAction m (WithSeverity VfsLog) -> J.DocumentChange -> m ()
+applyDocumentChange logger (J.InL               change)   = applyTextDocumentEdit logger change
+applyDocumentChange _      (J.InR (J.InL        change))  = applyCreateFile change
+applyDocumentChange _      (J.InR (J.InR (J.InL change))) = applyRenameFile change
+applyDocumentChange logger (J.InR (J.InR (J.InR change))) = applyDeleteFile logger change
 
--- ^ Applies the changes from a 'ApplyWorkspaceEditRequest' to the 'VFS'
-changeFromServerVFS :: VFS -> J.Message 'J.WorkspaceApplyEdit -> IO VFS
-changeFromServerVFS initVfs (J.RequestMessage _ _ _ params) = do
-  let J.ApplyWorkspaceEditParams _label edit = params
+-- | Applies the changes from a 'ApplyWorkspaceEditRequest' to the 'VFS'
+changeFromServerVFS :: forall m . MonadState VFS m => LogAction m (WithSeverity VfsLog) -> J.Message 'J.WorkspaceApplyEdit -> m ()
+changeFromServerVFS logger msg = do
+  let J.ApplyWorkspaceEditParams _label edit = msg ^. J.params
       J.WorkspaceEdit mChanges mDocChanges _anns = edit
   case mDocChanges of
     Just (J.List docChanges) -> applyDocumentChanges docChanges
     Nothing -> case mChanges of
       Just cs -> applyDocumentChanges $ map J.InL $ HashMap.foldlWithKey' changeToTextDocumentEdit [] cs
-      Nothing -> do
-        debugM "haskell-lsp.changeVfs" "No changes"
-        return initVfs
+      Nothing -> pure ()
 
   where
     changeToTextDocumentEdit acc uri edits =
       acc ++ [J.TextDocumentEdit (J.VersionedTextDocumentIdentifier uri (Just 0)) (fmap J.InL edits)]
 
-    applyDocumentChanges :: [J.DocumentChange] -> IO VFS 
-    applyDocumentChanges = foldM (flip applyDocumentChange) initVfs . sortOn project
-        
+    applyDocumentChanges :: [J.DocumentChange] -> m ()
+    applyDocumentChanges = traverse_ (applyDocumentChange logger) . sortOn project
+
     -- for sorting [DocumentChange]
     project :: J.DocumentChange -> J.TextDocumentVersion -- type TextDocumentVersion = Maybe Int
     project (J.InL textDocumentEdit) = textDocumentEdit ^. J.textDocument . J.version
@@ -251,58 +288,61 @@ virtualFileName prefix uri (VirtualFile _ file_ver _) =
   in prefix </> basename ++ "-" ++ padLeft 5 file_ver ++ "-" ++ show (hash uri_raw) <.> takeExtensions basename
 
 -- | Write a virtual file to a temporary file if it exists in the VFS.
-persistFileVFS :: VFS -> J.NormalizedUri -> Maybe (FilePath, IO ())
-persistFileVFS vfs uri =
-  case Map.lookup uri (vfsMap vfs) of
+persistFileVFS :: (MonadIO m) => LogAction m (WithSeverity VfsLog) -> VFS -> J.NormalizedUri -> Maybe (FilePath, m ())
+persistFileVFS logger vfs uri =
+  case vfs ^. vfsMap . at uri of
     Nothing -> Nothing
     Just vf ->
-      let tfn = virtualFileName (vfsTempDir vfs) uri vf
+      let tfn = virtualFileName (vfs ^. vfsTempDir) uri vf
           action = do
-            exists <- doesFileExist tfn
+            exists <- liftIO $ doesFileExist tfn
             unless exists $ do
-               let contents = T.unpack (Rope.toText (_text vf))
+               let contents = Rope.toText (_file_text vf)
                    writeRaw h = do
                     -- We honour original file line endings
                     hSetNewlineMode h noNewlineTranslation
                     hSetEncoding h utf8
-                    hPutStr h contents
-               debugM "haskell-lsp.persistFileVFS" $ "Writing virtual file: " 
-                    ++ "uri = " ++ show uri ++ ", virtual file = " ++ show tfn
-               withFile tfn WriteMode writeRaw
+                    T.hPutStr h contents
+               logger <& PersistingFile uri tfn `WithSeverity` Debug
+               liftIO $ withFile tfn WriteMode writeRaw
       in Just (tfn, action)
 
 -- ---------------------------------------------------------------------
 
-closeVFS :: VFS -> J.Message 'J.TextDocumentDidClose -> (VFS, [String])
-closeVFS vfs (J.NotificationMessage _ _ params) =
-  let J.DidCloseTextDocumentParams (J.TextDocumentIdentifier uri) = params
-  in (updateVFS (Map.delete (J.toNormalizedUri uri)) vfs,["Closed: " ++ show uri])
+closeVFS :: (MonadState VFS m) => LogAction m (WithSeverity VfsLog) -> J.Message 'J.TextDocumentDidClose -> m ()
+closeVFS logger msg = do
+  let J.DidCloseTextDocumentParams (J.TextDocumentIdentifier (J.toNormalizedUri -> uri)) = msg ^. J.params
+  logger <& Closing uri `WithSeverity` Debug
+  vfsMap . at uri .= Nothing
 
 -- ---------------------------------------------------------------------
 
 -- | Apply the list of changes.
 -- Changes should be applied in the order that they are
 -- received from the client.
-applyChanges :: Rope -> [J.TextDocumentContentChangeEvent] -> Rope
-applyChanges = foldl' applyChange
+applyChanges :: (Monad m) => LogAction m (WithSeverity VfsLog) -> Rope -> [J.TextDocumentContentChangeEvent] -> m Rope
+applyChanges logger = foldM (applyChange logger)
 
 -- ---------------------------------------------------------------------
 
-applyChange :: Rope -> J.TextDocumentContentChangeEvent -> Rope
-applyChange _ (J.TextDocumentContentChangeEvent Nothing Nothing str)
-  = Rope.fromText str
-applyChange str (J.TextDocumentContentChangeEvent (Just (J.Range (J.Position sl sc) (J.Position fl fc))) _ txt)
-  = changeChars str (Rope.Position (fromIntegral sl) (fromIntegral sc)) (Rope.Position (fromIntegral fl) (fromIntegral fc)) txt
-applyChange str (J.TextDocumentContentChangeEvent Nothing (Just _) _txt)
-  = str
+applyChange :: (Monad m) => LogAction m (WithSeverity VfsLog) -> Rope -> J.TextDocumentContentChangeEvent -> m Rope
+applyChange _ _ (J.TextDocumentContentChangeEvent Nothing _ str)
+  = pure $ Rope.fromText str
+applyChange logger str (J.TextDocumentContentChangeEvent (Just (J.Range (J.Position sl sc) (J.Position fl fc))) _ txt)
+  = changeChars logger str (Rope.Position (fromIntegral sl) (fromIntegral sc)) (Rope.Position (fromIntegral fl) (fromIntegral fc)) txt
 
 -- ---------------------------------------------------------------------
 
-changeChars :: Rope -> Rope.Position -> Rope.Position -> Text -> Rope
-changeChars str start finish new = mconcat [before', Rope.fromText new, after]
-  where
-    (before, after) = fromJust $ Rope.splitAtPosition finish str
-    (before', _) = fromJust $ Rope.splitAtPosition start before
+-- | Given a 'Rope', start and end positions, and some new text, replace
+-- the given range with the new text. If the given positions lie within
+-- a code point then this does nothing (returns the original 'Rope') and logs.
+changeChars :: (Monad m) => LogAction m (WithSeverity VfsLog) -> Rope -> Rope.Position -> Rope.Position -> Text -> m Rope
+changeChars logger str start finish new = do
+ case Rope.splitAtPosition finish str of
+   Nothing -> logger <& SplitInsideCodePoint finish str `WithSeverity` Warning >> pure str
+   Just (before, after) ->  case Rope.splitAtPosition start before of
+     Nothing -> logger <& SplitInsideCodePoint start before `WithSeverity` Warning >> pure str
+     Just (before', _) -> pure $ mconcat [before', Rope.fromText new, after]
 
 -- ---------------------------------------------------------------------
 

--- a/lsp/test/VspSpec.hs
+++ b/lsp/test/VspSpec.hs
@@ -8,6 +8,7 @@ import qualified Language.LSP.Types as J
 import qualified Data.Text as T
 
 import           Test.Hspec
+import Data.Functor.Identity
 
 -- ---------------------------------------------------------------------
 
@@ -40,7 +41,7 @@ vspSpec = do
             , J.TextDocumentContentChangeEvent (Just $ J.mkRange 0 1 0 2) Nothing ""
             , J.TextDocumentContentChangeEvent (Just $ J.mkRange 0 0 0 1) Nothing ""
             ]
-      applyChanges orig changes `shouldBe` ""
+      applyChanges mempty orig changes `shouldBe` Identity ""
     it "handles vscode style redos" $ do
       let orig = ""
           changes =
@@ -48,7 +49,7 @@ vspSpec = do
             , J.TextDocumentContentChangeEvent (Just $ J.mkRange 0 2 0 2) Nothing "b"
             , J.TextDocumentContentChangeEvent (Just $ J.mkRange 0 3 0 3) Nothing "c"
             ]
-      applyChanges orig changes `shouldBe` "abc"
+      applyChanges mempty orig changes `shouldBe` Identity "abc"
 
     -- ---------------------------------
 
@@ -62,9 +63,9 @@ vspSpec = do
           , "-- fooo"
           , "foo :: Int"
           ]
-        new = applyChange (fromString orig)
+        new = applyChange mempty (fromString orig)
                 $ J.TextDocumentContentChangeEvent (Just $ J.mkRange 2 1 2 5) (Just 4) ""
-      Rope.lines new `shouldBe`
+      Rope.lines <$> new `shouldBe` Identity
           [ "abcdg"
           , "module Foo where"
           , "-oo"
@@ -79,9 +80,9 @@ vspSpec = do
           , "-- fooo"
           , "foo :: Int"
           ]
-        new = applyChange (fromString orig)
+        new = applyChange mempty (fromString orig)
                 $ J.TextDocumentContentChangeEvent (Just $ J.mkRange 2 1 2 5) Nothing ""
-      Rope.lines new `shouldBe`
+      Rope.lines <$> new `shouldBe` Identity
           [ "abcdg"
           , "module Foo where"
           , "-oo"
@@ -99,9 +100,9 @@ vspSpec = do
           , "-- fooo"
           , "foo :: Int"
           ]
-        new = applyChange (fromString orig)
+        new = applyChange mempty (fromString orig)
                 $ J.TextDocumentContentChangeEvent (Just $ J.mkRange 2 0 3 0) (Just 8) ""
-      Rope.lines new `shouldBe`
+      Rope.lines <$> new `shouldBe` Identity
           [ "abcdg"
           , "module Foo where"
           , "foo :: Int"
@@ -116,9 +117,9 @@ vspSpec = do
           , "-- fooo"
           , "foo :: Int"
           ]
-        new = applyChange (fromString orig)
+        new = applyChange mempty (fromString orig)
                 $ J.TextDocumentContentChangeEvent (Just $ J.mkRange 2 0 3 0) Nothing ""
-      Rope.lines new `shouldBe`
+      Rope.lines <$> new `shouldBe` Identity
           [ "abcdg"
           , "module Foo where"
           , "foo :: Int"
@@ -134,9 +135,9 @@ vspSpec = do
           , "foo :: Int"
           , "foo = bb"
           ]
-        new = applyChange (fromString orig)
+        new = applyChange mempty (fromString orig)
                 $ J.TextDocumentContentChangeEvent (Just $ J.mkRange 1 0 3 0) (Just 19) ""
-      Rope.lines new `shouldBe`
+      Rope.lines <$> new `shouldBe` Identity
           [ "module Foo where"
           , "foo = bb"
           ]
@@ -150,9 +151,9 @@ vspSpec = do
           , "foo :: Int"
           , "foo = bb"
           ]
-        new = applyChange (fromString orig)
+        new = applyChange mempty (fromString orig)
                 $ J.TextDocumentContentChangeEvent (Just $ J.mkRange 1 0 3 0) Nothing ""
-      Rope.lines new `shouldBe`
+      Rope.lines <$> new `shouldBe` Identity
           [ "module Foo where"
           , "foo = bb"
           ]
@@ -167,9 +168,9 @@ vspSpec = do
           , "module Foo where"
           , "foo :: Int"
           ]
-        new = applyChange (fromString orig)
+        new = applyChange mempty (fromString orig)
                 $ J.TextDocumentContentChangeEvent (Just $ J.mkRange 1 16 1 16) (Just 0) "\n-- fooo"
-      Rope.lines new `shouldBe`
+      Rope.lines <$> new `shouldBe` Identity
           [ "abcdg"
           , "module Foo where"
           , "-- fooo"
@@ -185,9 +186,9 @@ vspSpec = do
           [ "module Foo where"
           , "foo = bb"
           ]
-        new = applyChange (fromString orig)
+        new = applyChange mempty (fromString orig)
                 $ J.TextDocumentContentChangeEvent (Just $ J.mkRange 1 8 1 8) Nothing "\n-- fooo\nfoo :: Int"
-      Rope.lines new `shouldBe`
+      Rope.lines <$> new `shouldBe` Identity
           [ "module Foo where"
           , "foo = bb"
           , "-- fooo"
@@ -212,9 +213,9 @@ vspSpec = do
           , "  putStrLn \"hello world\""
           ]
         -- new = changeChars (fromString orig) (J.Position 7 0) (J.Position 7 8) "baz ="
-        new = applyChange (fromString orig)
+        new = applyChange mempty (fromString orig)
                 $ J.TextDocumentContentChangeEvent (Just $ J.mkRange 7 0 7 8) (Just 8) "baz ="
-      Rope.lines new `shouldBe`
+      Rope.lines <$> new `shouldBe` Identity
           [ "module Foo where"
           , "-- fooo"
           , "foo :: Int"
@@ -240,9 +241,9 @@ vspSpec = do
           , "  putStrLn \"hello world\""
           ]
         -- new = changeChars (fromString orig) (J.Position 7 0) (J.Position 7 8) "baz ="
-        new = applyChange (fromString orig)
+        new = applyChange mempty (fromString orig)
                 $ J.TextDocumentContentChangeEvent (Just $ J.mkRange 7 0 7 8) Nothing "baz ="
-      Rope.lines new `shouldBe`
+      Rope.lines <$> new `shouldBe` Identity
           [ "module Foo where"
           , "-- fooo"
           , "foo :: Int"
@@ -259,9 +260,9 @@ vspSpec = do
           [ "a𐐀b"
           , "a𐐀b"
           ]
-        new = applyChange (fromString orig)
+        new = applyChange mempty (fromString orig)
                 $ J.TextDocumentContentChangeEvent (Just $ J.mkRange 1 0 1 3) (Just 3) "𐐀𐐀"
-      Rope.lines new `shouldBe`
+      Rope.lines <$> new `shouldBe` Identity
           [ "a𐐀b"
           , "𐐀𐐀b"
           ]

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,3 +11,4 @@ nix:
   packages: [icu]
 extra-deps:
 - text-rope-0.1
+- co-log-core-0.3.1.0


### PR DESCRIPTION
This started as an attempt to bubble up errors from the VFS as actual
errors and return them to the user via the LSP response. However, in
fact VFS operations occur in response to notifications, which don't have
responses.

So all we can do is log the error and drop the change, which is okay.
However, that made me look at how the logging works. At the moment we
use `hslogger`, which is fine, but isn't so great when it's plugging
into part of a larger system. For example, we might want to have a
global log handler that sends error-level logs to the client as
messages, or uses the `logMessage` method of the LSP spec. But there's no
way to intercept the messages sent by the VFS currently.

So I switched over to using `co-log-core`, which is also the direction
that [HLS is going](https://github.com/haskell/haskell-language-server/pull/2558).

`co-log-core` is also a lightweight dependency.
It's suboptimal for `lsp-types` to depend on a logging library, however, but that
should be fixed when we do https://github.com/haskell/lsp/issues/394.