### PR TITLE
Add STM function to snapshot VFS

### DIFF
--- a/lsp/src/Language/LSP/Server.hs
+++ b/lsp/src/Language/LSP/Server.hs
@@ -38,6 +38,7 @@ module Language.LSP.Server
   , persistVirtualFile
   , getVersionedTextDoc
   , reverseFileMap
+  , snapshotVirtualFiles
 
   -- * Diagnostics
   , publishDiagnostics

--- a/lsp/src/Language/LSP/Server/Core.hs
+++ b/lsp/src/Language/LSP/Server/Core.hs
@@ -380,6 +380,13 @@ getVirtualFiles = vfsData <$> getsState resVFS
 
 {-# INLINE getVirtualFiles #-}
 
+-- | Take an atomic snapshot of the current state of the virtual file system.
+snapshotVirtualFiles :: LanguageContextEnv c -> STM VFS
+snapshotVirtualFiles env = vfsData <$> readTVar (resVFS $ resState env)
+
+{-# INLINE snapshotVirtualFiles #-}
+
+
 -- | Dump the current text for a given VFS file to a temporary file,
 -- and return the path to the file.
 persistVirtualFile :: MonadLsp config m => NormalizedUri -> m (Maybe FilePath)


### PR DESCRIPTION
This is useful if you want to take a snapshot of the entire VFS state at a particular point.
