### PR TITLE
fix typos

### DIFF
--- a/lsp-test/src/Language/LSP/Test.hs
+++ b/lsp-test/src/Language/LSP/Test.hs
@@ -151,7 +151,7 @@ runSession :: String -- ^ The command to run the server.
            -> IO a
 runSession = runSessionWithConfig def
 
--- | Starts a new sesion with a custom configuration.
+-- | Starts a new session with a custom configuration.
 runSessionWithConfig :: SessionConfig -- ^ Configuration options for the session.
                      -> String -- ^ The command to run the server.
                      -> C.ClientCapabilities -- ^ The capabilities that the client should declare.
@@ -703,7 +703,7 @@ getHover doc pos =
   let params = HoverParams doc pos Nothing
   in getResponseResult <$> request STextDocumentHover params
 
--- | Returns the highlighted occurences of the term at the specified position
+-- | Returns the highlighted occurrences of the term at the specified position
 getHighlights :: TextDocumentIdentifier -> Position -> Session (List DocumentHighlight)
 getHighlights doc pos =
   let params = DocumentHighlightParams doc pos Nothing Nothing

--- a/lsp-types/src/Language/LSP/Types/Lens.hs
+++ b/lsp-types/src/Language/LSP/Types/Lens.hs
@@ -56,7 +56,7 @@ import           Language.LSP.Types.Message
 import           Language.LSP.Types.SemanticTokens
 import           Control.Lens.TH
 
--- TODO: This is out of date and very unmantainable, use TH to call all these!!
+-- TODO: This is out of date and very unmaintainable, use TH to call all these!!
 
 -- client capabilities
 makeFieldsNoPrefix ''MessageActionItemClientCapabilities

--- a/lsp-types/src/Language/LSP/Types/Parsing.hs
+++ b/lsp-types/src/Language/LSP/Types/Parsing.hs
@@ -29,7 +29,7 @@ import Data.Type.Equality
 import Data.Function (on)
 
 -- ---------------------------------------------------------------------
--- Working with arbritary messages
+-- Working with arbitrary messages
 -- ---------------------------------------------------------------------
 
 data FromServerMessage' a where

--- a/lsp-types/src/Language/LSP/Types/SMethodMap.hs
+++ b/lsp-types/src/Language/LSP/Types/SMethodMap.hs
@@ -28,7 +28,7 @@ import Language.LSP.Types.Method (Method(..), SMethod(..))
 
 -- This type exists to avoid a dependency on 'dependent-map'. It is less
 -- safe (since we use 'unsafeCoerce') but much simpler and hence easier to include.
--- | A specialized altenative to a full dependent map for use with 'SMethod'.
+-- | A specialized alternative to a full dependent map for use with 'SMethod'.
 data SMethodMap (v :: Method f t -> Type) =
   -- This works by using an 'IntMap' indexed by constructor tag for the majority
   -- of 'SMethod's, which have no parameters, and hence can only appear once as keys

--- a/lsp/src/Language/LSP/Server/Core.hs
+++ b/lsp/src/Language/LSP/Server/Core.hs
@@ -252,7 +252,7 @@ instance Default Options where
 defaultOptions :: Options
 defaultOptions = def
 
--- | A package indicating the perecentage of progress complete and a
+-- | A package indicating the percentage of progress complete and a
 -- an optional message to go with it during a 'withProgress'
 --
 -- @since 0.10.0.0
@@ -319,7 +319,7 @@ data ServerDefinition config = forall m a.
 newtype ServerResponseCallback (m :: Method FromServer Request)
   = ServerResponseCallback (Either ResponseError (ResponseResult m) -> IO ())
 
--- | Return value signals if response handler was inserted succesfully
+-- | Return value signals if response handler was inserted successfully
 -- Might fail if the id was already in the map
 addResponseHandler :: MonadLsp config f => LspId m -> (Product SMethod ServerResponseCallback) m -> f Bool
 addResponseHandler lid h = do


### PR DESCRIPTION
lsp-test/src/Language/LSP/Test.hs
lsp-types/src/Language/LSP/Types/Lens.hs
lsp-types/src/Language/LSP/Types/Parsing.hs
lsp-types/src/Language/LSP/Types/SMethodMap.hs
lsp/src/Language/LSP/Server/Core.hs

<hr>

for another PR this line could be rewritten

lsp-test/src/Language/LSP/Test/Replay.hs

`-- | Swaps out any commands uniqued with process IDs to match the specified process ID`
