### PR TITLE
Extend the list of exposed modules of lsp-types by those modules whic…

### DIFF
--- a/lsp-types/lsp-types.cabal
+++ b/lsp-types/lsp-types.cabal
@@ -18,24 +18,14 @@ extra-source-files:  ChangeLog.md, README.md
 
 library
   exposed-modules:     Language.LSP.Types
+                     , Language.LSP.Types.CallHierarchy
                      , Language.LSP.Types.Capabilities
-                     , Language.LSP.Types.Lens
-                     , Language.LSP.Types.SMethodMap
-                     , Data.IxMap
-  other-modules:       Language.LSP.Types.CallHierarchy
-                     , Language.LSP.Types.Cancellation
-                     , Language.LSP.Types.ClientCapabilities
                      , Language.LSP.Types.CodeAction
                      , Language.LSP.Types.CodeLens
-                     , Language.LSP.Types.Command
-                     , Language.LSP.Types.Common
                      , Language.LSP.Types.Completion
-                     , Language.LSP.Types.Configuration
                      , Language.LSP.Types.Declaration
                      , Language.LSP.Types.Definition
-                     , Language.LSP.Types.Diagnostic
                      , Language.LSP.Types.DocumentColor
-                     , Language.LSP.Types.DocumentFilter
                      , Language.LSP.Types.DocumentHighlight
                      , Language.LSP.Types.DocumentLink
                      , Language.LSP.Types.DocumentSymbol
@@ -43,6 +33,22 @@ library
                      , Language.LSP.Types.Formatting
                      , Language.LSP.Types.Hover
                      , Language.LSP.Types.Implementation
+                     , Language.LSP.Types.Lens
+                     , Language.LSP.Types.References
+                     , Language.LSP.Types.Rename
+                     , Language.LSP.Types.SelectionRange
+                     , Language.LSP.Types.SemanticTokens
+                     , Language.LSP.Types.SignatureHelp
+                     , Language.LSP.Types.SMethodMap
+                     , Language.LSP.Types.TypeDefinition
+                     , Data.IxMap
+  other-modules:       Language.LSP.Types.Cancellation
+                     , Language.LSP.Types.ClientCapabilities
+                     , Language.LSP.Types.Command
+                     , Language.LSP.Types.Common
+                     , Language.LSP.Types.Configuration
+                     , Language.LSP.Types.Diagnostic
+                     , Language.LSP.Types.DocumentFilter
                      , Language.LSP.Types.Initialize
                      , Language.LSP.Types.Location
                      , Language.LSP.Types.LspId
@@ -52,15 +58,9 @@ library
                      , Language.LSP.Types.Parsing
                      , Language.LSP.Types.Progress
                      , Language.LSP.Types.Registration
-                     , Language.LSP.Types.References
-                     , Language.LSP.Types.Rename
-                     , Language.LSP.Types.SelectionRange
                      , Language.LSP.Types.ServerCapabilities
-                     , Language.LSP.Types.SemanticTokens
-                     , Language.LSP.Types.SignatureHelp
                      , Language.LSP.Types.StaticRegistrationOptions
                      , Language.LSP.Types.TextDocument
-                     , Language.LSP.Types.TypeDefinition
                      , Language.LSP.Types.Uri
                      , Language.LSP.Types.Utils
                      , Language.LSP.Types.Window

--- a/lsp-types/src/Language/LSP/Types.hs
+++ b/lsp-types/src/Language/LSP/Types.hs
@@ -1,24 +1,10 @@
 module Language.LSP.Types
-  ( module Language.LSP.Types.CallHierarchy
-  , module Language.LSP.Types.Cancellation
-  , module Language.LSP.Types.CodeAction
-  , module Language.LSP.Types.CodeLens
+  ( module Language.LSP.Types.Cancellation
   , module Language.LSP.Types.Command
   , module Language.LSP.Types.Common
-  , module Language.LSP.Types.Completion
   , module Language.LSP.Types.Configuration
-  , module Language.LSP.Types.Declaration
-  , module Language.LSP.Types.Definition
   , module Language.LSP.Types.Diagnostic
-  , module Language.LSP.Types.DocumentColor
   , module Language.LSP.Types.DocumentFilter
-  , module Language.LSP.Types.DocumentHighlight
-  , module Language.LSP.Types.DocumentLink
-  , module Language.LSP.Types.DocumentSymbol
-  , module Language.LSP.Types.FoldingRange
-  , module Language.LSP.Types.Formatting
-  , module Language.LSP.Types.Hover
-  , module Language.LSP.Types.Implementation
   , module Language.LSP.Types.Initialize
   , module Language.LSP.Types.Location
   , module Language.LSP.Types.LspId
@@ -27,21 +13,36 @@ module Language.LSP.Types
   , module Language.LSP.Types.Message
   , module Language.LSP.Types.Parsing
   , module Language.LSP.Types.Progress
-  , module Language.LSP.Types.References
   , module Language.LSP.Types.Registration
-  , module Language.LSP.Types.Rename
-  , module Language.LSP.Types.SignatureHelp
   , module Language.LSP.Types.StaticRegistrationOptions
-  , module Language.LSP.Types.SelectionRange
-  , module Language.LSP.Types.SemanticTokens
   , module Language.LSP.Types.TextDocument
-  , module Language.LSP.Types.TypeDefinition
   , module Language.LSP.Types.Uri
   , module Language.LSP.Types.WatchedFiles
   , module Language.LSP.Types.Window
   , module Language.LSP.Types.WorkspaceEdit
   , module Language.LSP.Types.WorkspaceFolders
   , module Language.LSP.Types.WorkspaceSymbol
+   -- * Language Features
+  , module Language.LSP.Types.CallHierarchy
+  , module Language.LSP.Types.CodeAction
+  , module Language.LSP.Types.CodeLens
+  , module Language.LSP.Types.Completion
+  , module Language.LSP.Types.Declaration
+  , module Language.LSP.Types.Definition
+  , module Language.LSP.Types.DocumentColor
+  , module Language.LSP.Types.DocumentHighlight
+  , module Language.LSP.Types.DocumentLink
+  , module Language.LSP.Types.DocumentSymbol
+  , module Language.LSP.Types.FoldingRange
+  , module Language.LSP.Types.Formatting
+  , module Language.LSP.Types.Hover
+  , module Language.LSP.Types.Implementation
+  , module Language.LSP.Types.References
+  , module Language.LSP.Types.Rename
+  , module Language.LSP.Types.SelectionRange
+  , module Language.LSP.Types.SemanticTokens
+  , module Language.LSP.Types.SignatureHelp
+  , module Language.LSP.Types.TypeDefinition
   )
 where
 


### PR DESCRIPTION
The documentation of the types defined in the lsp-types library could be improved (cf. #419). As a first step, more modules should probably be exposed. As one step in this direction, this PR exposes all the modules which correspond to "Language features" on the official documentation site of the LSP protocol: https://microsoft.github.io/language-server-protocol/specification
The mapping is not 1:1, since the official documentation is not super sensibly organized either, but maybe this choice of exposed modules is a sensible first step.
