### PR TITLE
Fix #268 by introducing a MaybeN type

### DIFF
--- a/lsp-test/src/Language/LSP/Test.hs
+++ b/lsp-test/src/Language/LSP/Test.hs
@@ -200,14 +200,14 @@ runSessionWithHandles' serverProc serverIn serverOut config' caps rootDir sessio
   let initializeParams = InitializeParams Nothing
                                           -- Narrowing to Int32 here, but it's unlikely that a PID will
                                           -- be outside the range
-                                          (Just $ fromIntegral pid)
+                                          (JustN $ fromIntegral pid)
                                           (Just lspTestClientInfo)
-                                          (Just $ T.pack absRootDir)
-                                          (Just $ filePathToUri absRootDir)
+                                          (JustN $ T.pack absRootDir)
+                                          (JustN $ filePathToUri absRootDir)
                                           (lspConfig config')
                                           caps
                                           (Just TraceOff)
-                                          (List <$> initialWorkspaceFolders config)
+                                          (maybeN (List <$> initialWorkspaceFolders config))
   runSession' serverIn serverOut serverProc listenServer config caps rootDir exitServer $ do
     -- Wrap the session around initialize and shutdown calls
     initReqId <- sendRequest SInitialize initializeParams

--- a/lsp-test/src/Language/LSP/Test/Files.hs
+++ b/lsp-test/src/Language/LSP/Test/Files.hs
@@ -40,7 +40,7 @@ swapFiles relCurBaseDir msgs = do
 rootDir :: [Event] -> FilePath
 rootDir (ClientEv _ (FromClientMess SInitialize req):_) =
   fromMaybe (error "Couldn't find root dir") $ do
-    rootUri <- req ^. params .rootUri
+    rootUri <- unMaybeN (req ^. params . rootUri)
     uriToFilePath rootUri
 rootDir _ = error "Couldn't find initialize request in session"
 
@@ -99,7 +99,7 @@ mapUris f event =
     transformInit x =
       let newRootUri = fmap f (x ^. rootUri)
           newRootPath = do
-            fp <- T.unpack <$> x ^. rootPath
+            fp <- T.unpack <$> unMaybeN (x ^. rootPath)
             let uri = filePathToUri fp
             T.pack <$> uriToFilePath (f uri)
-        in (rootUri .~ newRootUri) $ (rootPath .~ newRootPath) x
+        in (rootUri .~ newRootUri) $ (rootPath .~ maybeN newRootPath) x

--- a/lsp-types/src/Language/LSP/Types/Initialize.hs
+++ b/lsp-types/src/Language/LSP/Types/Initialize.hs
@@ -41,14 +41,14 @@ data ClientInfo =
 deriveJSON lspOptions ''ClientInfo
 
 makeExtendingDatatype "InitializeParams" [''WorkDoneProgressParams]
-  [ ("_processId",             [t| Maybe Int32|])
+  [ ("_processId",             [t| MaybeN Int32|])
   , ("_clientInfo",            [t| Maybe ClientInfo |])
-  , ("_rootPath",              [t| Maybe Text |])
-  , ("_rootUri",               [t| Maybe Uri  |])
+  , ("_rootPath",              [t| MaybeN Text |])
+  , ("_rootUri",               [t| MaybeN Uri |])
   , ("_initializationOptions", [t| Maybe Value |])
   , ("_capabilities",          [t| ClientCapabilities |])
   , ("_trace",                 [t| Maybe Trace |])
-  , ("_workspaceFolders",      [t| Maybe (List WorkspaceFolder) |])
+  , ("_workspaceFolders",      [t| MaybeN (List WorkspaceFolder) |])
   ]
 
 deriveJSON lspOptions ''InitializeParams
@@ -93,4 +93,3 @@ instance FromJSON InitializedParams where
 
 instance ToJSON InitializedParams where
   toJSON InitializedParams = Object mempty
-

--- a/lsp/src/Language/LSP/Server/Processing.hs
+++ b/lsp/src/Language/LSP/Server/Processing.hs
@@ -120,12 +120,12 @@ initializeRequestHandler ServerDefinition{..} vfs sendFunc req = do
   flip E.catch (initializeErrorHandler $ sendResp . makeResponseError (req ^. LSP.id)) $ handleErr <=< runExceptT $ mdo
 
     let params = req ^. LSP.params
-        rootDir = getFirst $ foldMap First [ params ^. LSP.rootUri  >>= uriToFilePath
-                                           , params ^. LSP.rootPath <&> T.unpack ]
+        rootDir = getFirst $ foldMap First [ unMaybeN (params ^. LSP.rootUri) >>= uriToFilePath
+                                           , unMaybeN (params ^. LSP.rootPath) <&> T.unpack ]
 
     let initialWfs = case params ^. LSP.workspaceFolders of
-          Just (List xs) -> xs
-          Nothing -> []
+          JustN (List xs) -> xs
+          NothingN -> []
 
         initialConfig = case onConfigurationChange defaultConfig <$> (req ^. LSP.params . LSP.initializationOptions) of
           Just (Right newConfig) -> newConfig


### PR DESCRIPTION
Taking a stab at fixing #268 by introducing a new `MaybeN` type, which is just like `Maybe` except that `Nothing` values get encoded to JSON `null`. This is inspired by the existing `List` type.

This can be used to conform properly to the LSP spec, which sometimes specifies types like `a | null` and sometimes `a?` (i.e. omit the value when absent).

The downside of this approach is that for every field you convert from `Maybe` to `MaybeN`, you have to go through all usages of that field and change them. I've included an example of doing this for `InitializeParams`; for full compliance we would have to do the same for all `Maybe` fields that are supposed to be `a | null`.

Of course, it's unpleasant to expose this encoding detail in the field types and make all these changes. This seemed like the most straightforward way, but a cleaner approach might be possible with TH. For example, maybe we could extend `makeExtendingDataType` so that it takes extra arguments indicating which type of `Maybe` to use, and generates suitable `FromJSON`/`ToJSON` instances manually? FWIW a search through the LSP spec indicates about 40 cases of `| null` to handle.