### PR TITLE
Spec compliance: "workspaceSymbolProvider?: boolean | WorkspaceSymbolOptions"

### DIFF
--- a/lsp-types/src/Language/LSP/Types/ServerCapabilities.hs
+++ b/lsp-types/src/Language/LSP/Types/ServerCapabilities.hs
@@ -31,6 +31,7 @@ import Language.LSP.Types.SignatureHelp
 import Language.LSP.Types.TextDocument
 import Language.LSP.Types.TypeDefinition
 import Language.LSP.Types.Utils
+import Language.LSP.Types.WorkspaceSymbol
 
 -- ---------------------------------------------------------------------
 
@@ -126,7 +127,7 @@ data ServerCapabilities =
       -- @since 3.16.0
     , _semanticTokensProvider           :: Maybe (SemanticTokensOptions |? SemanticTokensRegistrationOptions)
       -- | The server provides workspace symbol support.
-    , _workspaceSymbolProvider          :: Maybe Bool
+    , _workspaceSymbolProvider          :: Maybe (Bool |? WorkspaceSymbolOptions)
       -- | Workspace specific server capabilities
     , _workspace                        :: Maybe WorkspaceServerCapabilities
       -- | Experimental server capabilities.

--- a/lsp/src/Language/LSP/Server/Processing.hs
+++ b/lsp/src/Language/LSP/Server/Processing.hs
@@ -201,7 +201,7 @@ inferServerCapabilities clientCaps o h =
     , _selectionRangeProvider           = supportedBool STextDocumentSelectionRange
     , _callHierarchyProvider            = supportedBool STextDocumentPrepareCallHierarchy
     , _semanticTokensProvider           = semanticTokensProvider
-    , _workspaceSymbolProvider          = supported SWorkspaceSymbol
+    , _workspaceSymbolProvider          = supportedBool SWorkspaceSymbol
     , _workspace                        = Just workspace
     -- TODO: Add something for experimental
     , _experimental                     = Nothing :: Maybe Value


### PR DESCRIPTION
This PR adds `WorkspaceSymbolOptions` as an option to `workspaceSymbolProvider` in `ServerCapabilities`, to be compliant with the LSP spec.

The lack of this option was causing a failure to parse the `ServerCapabilities` returned by [pyright](https://github.com/microsoft/pyright).

