### PR TITLE
LSP compliance: handle single MarkedString in Hover

### DIFF
--- a/lsp-types/src/Language/LSP/Types/Hover.hs
+++ b/lsp-types/src/Language/LSP/Types/Hover.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE TemplateHaskell  #-}
-{-# LANGUAGE DuplicateRecordFields      #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE TypeOperators #-}
+
 module Language.LSP.Types.Hover where
 
 import           Data.Aeson.TH
@@ -51,24 +53,6 @@ deriveJSON lspOptionsUntagged ''MarkedString
 
 -- -------------------------------------
 
-data HoverContents =
-    HoverContentsMS (List MarkedString)
-  | HoverContents   MarkupContent
-  deriving (Read,Show,Eq)
-
-deriveJSON lspOptionsUntagged ''HoverContents
-
--- -------------------------------------
-
-instance Semigroup HoverContents where
-  HoverContents h1   <> HoverContents         h2   = HoverContents (h1 `mappend` h2)
-  HoverContents h1   <> HoverContentsMS (List h2s) = HoverContents (mconcat (h1: (map toMarkupContent h2s)))
-  HoverContentsMS (List h1s) <> HoverContents         h2    = HoverContents (mconcat ((map toMarkupContent h1s) ++ [h2]))
-  HoverContentsMS (List h1s) <> HoverContentsMS (List h2s) = HoverContentsMS (List (h1s `mappend` h2s))
-
-instance Monoid HoverContents where
-  mempty = HoverContentsMS (List [])
-
 toMarkupContent :: MarkedString -> MarkupContent
 toMarkupContent (PlainString s) = unmarkedUpContent s
 toMarkupContent (CodeString (LanguageString lang s)) = markedUpContent lang s
@@ -77,7 +61,7 @@ toMarkupContent (CodeString (LanguageString lang s)) = markedUpContent lang s
 
 data Hover =
   Hover
-    { _contents :: HoverContents
+    { _contents :: MarkedString |? List MarkedString |? MarkupContent
     , _range    :: Maybe Range
     } deriving (Read,Show,Eq)
 

--- a/lsp/example/Reactor.hs
+++ b/lsp/example/Reactor.hs
@@ -264,7 +264,7 @@ handle logger = mconcat
       let J.HoverParams _doc pos _workDone = req ^. J.params
           J.Position _l _c' = pos
           rsp = J.Hover ms (Just range)
-          ms = J.HoverContents $ J.markedUpContent "lsp-hello" "Your type info here!"
+          ms = J.InR $ J.InR $ J.markedUpContent "lsp-hello" "Your type info here!"
           range = J.Range pos pos
       responder (Right $ Just rsp)
 

--- a/lsp/example/Simple.hs
+++ b/lsp/example/Simple.hs
@@ -29,7 +29,7 @@ handlers = mconcat
       let RequestMessage _ _ _ (HoverParams _doc pos _workDone) = req
           Position _l _c' = pos
           rsp = Hover ms (Just range)
-          ms = HoverContents $ markedUpContent "lsp-demo-simple-server" "Hello world"
+          ms = InR $ InR $ markedUpContent "lsp-demo-simple-server" "Hello world"
           range = Range pos pos
       responder (Right $ Just rsp)
   ]


### PR DESCRIPTION
This PR fixes the `_contents` field of `Hover` to try parsing a single `MarkedString`, as per the spec.

To do this I just removed the `HoverContents` type, which seems kind of unnecessary and inconsistent with the normal style of just using `|?`.

Getting rid of `HoverContents` requires minor changes in client code so this is a breaking change. `HoverContents` also came with a `Monoid`/`Semigroup` instance, but I couldn't find any place where it was actually used, either in this repo or `haskell-language-server`.

An alternative would have been to add another constructor to `HoverContents` for this case, which would make it a slightly less breaking change, but I was too horrified at the prospect of updating the `Semigroup` instance with another constructor...