### PR TITLE
Update version bounds in cabal files

### DIFF
--- a/lsp-test/lsp-test.cabal
+++ b/lsp-test/lsp-test.cabal
@@ -54,7 +54,7 @@ library
                      , filepath
                      , Glob >= 0.9 && < 0.11
                      , lens
-                     , mtl
+                     , mtl < 2.4
                      , parser-combinators >= 1.2
                      , process >= 1.6
                      , text
@@ -93,7 +93,7 @@ test-suite tests
                      , filepath
                      , unliftio
                      , process
-                     , mtl
+                     , mtl < 2.4
                      , aeson
   default-language:    Haskell2010
 

--- a/lsp-types/lsp-types.cabal
+++ b/lsp-types/lsp-types.cabal
@@ -81,7 +81,7 @@ library
                      , filepath
                      , hashable
                      , lens >= 4.15.2
-                     , mtl
+                     , mtl < 2.4
                      , network-uri
                      , mod
                      , scientific

--- a/lsp/lsp.cabal
+++ b/lsp/lsp.cabal
@@ -46,7 +46,7 @@ library
                      , hashable
                      , lsp-types == 1.5.*
                      , lens >= 4.15.2
-                     , mtl
+                     , mtl < 2.4
                      , network-uri
                      , prettyprinter
                      , sorted-list == 0.2.1.*
@@ -55,7 +55,7 @@ library
                      , temporary
                      , text
                      , text-rope
-                     , transformers >= 0.5.6 && < 0.6
+                     , transformers >= 0.5.6 && < 0.7
                      , time
                      , unordered-containers
                      , unliftio-core >= 0.2.0.0


### PR DESCRIPTION
I tested that we can build with `transformers-0.6` and `mtl-2.3`.