### PR TITLE
Add lower bounds for Diff and network-uri

### DIFF
--- a/lsp-test/lsp-test.cabal
+++ b/lsp-test/lsp-test.cabal
@@ -49,7 +49,7 @@ library
                      , conduit-parse == 0.2.*
                      , containers >= 0.5.9
                      , data-default
-                     , Diff
+                     , Diff >= 0.3
                      , directory
                      , filepath
                      , Glob >= 0.9 && < 0.11

--- a/lsp-types/lsp-types.cabal
+++ b/lsp-types/lsp-types.cabal
@@ -76,13 +76,13 @@ library
                      , containers
                      , data-default
                      , deepseq
-                     , Diff
+                     , Diff >= 0.2
                      , dlist
                      , filepath
                      , hashable
                      , lens >= 4.15.2
                      , mtl < 2.4
-                     , network-uri
+                     , network-uri >= 2.6
                      , mod
                      , scientific
                      , some


### PR DESCRIPTION
Otherwise `Network.URI` and `Data.Algorithm.DiffOutput` are not available yet.