### PR TITLE
Fix WorkspaceSemanticTokensRefresh type to be FromServer, not FromClient

### DIFF
--- a/lsp-types/src/Language/LSP/Types/Method.hs
+++ b/lsp-types/src/Language/LSP/Types/Method.hs
@@ -87,7 +87,6 @@ data Method (f :: From) (t :: MethodType) where
   TextDocumentSemanticTokensFull     :: Method FromClient Request
   TextDocumentSemanticTokensFullDelta :: Method FromClient Request
   TextDocumentSemanticTokensRange    :: Method FromClient Request
-  WorkspaceSemanticTokensRefresh     :: Method FromClient Request
 
 -- ServerMethods
   -- Window
@@ -108,6 +107,7 @@ data Method (f :: From) (t :: MethodType) where
   WorkspaceWorkspaceFolders          :: Method FromServer Request
   WorkspaceConfiguration             :: Method FromServer Request
   WorkspaceApplyEdit                 :: Method FromServer Request
+  WorkspaceSemanticTokensRefresh     :: Method FromServer Request
   -- Document
   TextDocumentPublishDiagnostics     :: Method FromServer Notification
 
@@ -287,7 +287,6 @@ instance FromJSON SomeClientMethod where
   parseJSON (A.String "workspace/didChangeWatchedFiles")     = pure $ SomeClientMethod SWorkspaceDidChangeWatchedFiles
   parseJSON (A.String "workspace/symbol")                    = pure $ SomeClientMethod SWorkspaceSymbol
   parseJSON (A.String "workspace/executeCommand")            = pure $ SomeClientMethod SWorkspaceExecuteCommand
-  parseJSON (A.String "workspace/semanticTokens/refresh")    = pure $ SomeClientMethod SWorkspaceSemanticTokensRefresh
  -- Document
   parseJSON (A.String "textDocument/didOpen")                = pure $ SomeClientMethod STextDocumentDidOpen
   parseJSON (A.String "textDocument/didChange")              = pure $ SomeClientMethod STextDocumentDidChange
@@ -351,6 +350,7 @@ instance A.FromJSON SomeServerMethod where
   parseJSON (A.String "workspace/workspaceFolders")          = pure $ SomeServerMethod SWorkspaceWorkspaceFolders
   parseJSON (A.String "workspace/configuration")             = pure $ SomeServerMethod SWorkspaceConfiguration
   parseJSON (A.String "workspace/applyEdit")                 = pure $ SomeServerMethod SWorkspaceApplyEdit
+  parseJSON (A.String "workspace/semanticTokens/refresh")    = pure $ SomeServerMethod SWorkspaceSemanticTokensRefresh
   -- Document
   parseJSON (A.String "textDocument/publishDiagnostics")     = pure $ SomeServerMethod STextDocumentPublishDiagnostics
 
@@ -388,7 +388,6 @@ instance A.ToJSON (SMethod m) where
   toJSON SWorkspaceDidChangeWatchedFiles     = A.String "workspace/didChangeWatchedFiles"
   toJSON SWorkspaceSymbol                    = A.String "workspace/symbol"
   toJSON SWorkspaceExecuteCommand            = A.String "workspace/executeCommand"
-  toJSON SWorkspaceSemanticTokensRefresh     = A.String "workspace/semanticTokens/refresh"
   -- Document
   toJSON STextDocumentDidOpen                = A.String "textDocument/didOpen"
   toJSON STextDocumentDidChange              = A.String "textDocument/didChange"
@@ -445,6 +444,7 @@ instance A.ToJSON (SMethod m) where
   toJSON SWorkspaceWorkspaceFolders          = A.String "workspace/workspaceFolders"
   toJSON SWorkspaceConfiguration             = A.String "workspace/configuration"
   toJSON SWorkspaceApplyEdit                 = A.String "workspace/applyEdit"
+  toJSON SWorkspaceSemanticTokensRefresh     = A.String "workspace/semanticTokens/refresh"
   -- Document
   toJSON STextDocumentPublishDiagnostics     = A.String "textDocument/publishDiagnostics"
   -- Cancelling

--- a/lsp-types/src/Language/LSP/Types/Parsing.hs
+++ b/lsp-types/src/Language/LSP/Types/Parsing.hs
@@ -259,12 +259,12 @@ splitClientMethod STextDocumentSemanticTokens = IsClientReq
 splitClientMethod STextDocumentSemanticTokensFull = IsClientReq
 splitClientMethod STextDocumentSemanticTokensFullDelta = IsClientReq
 splitClientMethod STextDocumentSemanticTokensRange = IsClientReq
-splitClientMethod SWorkspaceSemanticTokensRefresh  = IsClientReq
 splitClientMethod SCancelRequest = IsClientNot
 splitClientMethod SCustomMethod{} = IsClientEither
 
 {-# INLINE splitServerMethod #-}
 splitServerMethod :: SServerMethod m -> ServerNotOrReq m
+-- Window
 splitServerMethod SWindowShowMessage = IsServerNot
 splitServerMethod SWindowShowMessageRequest = IsServerReq
 splitServerMethod SWindowShowDocument = IsServerReq
@@ -272,13 +272,19 @@ splitServerMethod SWindowLogMessage = IsServerNot
 splitServerMethod SWindowWorkDoneProgressCreate = IsServerReq
 splitServerMethod SProgress = IsServerNot
 splitServerMethod STelemetryEvent = IsServerNot
+-- Client
 splitServerMethod SClientRegisterCapability = IsServerReq
 splitServerMethod SClientUnregisterCapability = IsServerReq
+-- Workspace
 splitServerMethod SWorkspaceWorkspaceFolders = IsServerReq
 splitServerMethod SWorkspaceConfiguration = IsServerReq
 splitServerMethod SWorkspaceApplyEdit = IsServerReq
+splitServerMethod SWorkspaceSemanticTokensRefresh = IsServerReq
+-- Document
 splitServerMethod STextDocumentPublishDiagnostics = IsServerNot
+-- Cancelling
 splitServerMethod SCancelRequest = IsServerNot
+-- Custom
 splitServerMethod SCustomMethod{} = IsServerEither
 
 -- | Given a witness that two custom methods are of the same type, produce a witness that the methods are the same


### PR DESCRIPTION
This method is currently miscategorized as a `Method FromClient Request`, but it should be a `Method FromServer Request`.

See here:

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#semanticTokens_refreshRequest