### PR TITLE
lsp-test: Add MonadThrow instance to Session

### DIFF
--- a/lsp-test/lsp-test.cabal
+++ b/lsp-test/lsp-test.cabal
@@ -51,6 +51,7 @@ library
                      , data-default
                      , Diff >= 0.3
                      , directory
+                     , exceptions
                      , filepath
                      , Glob >= 0.9 && < 0.11
                      , lens
@@ -101,7 +102,7 @@ test-suite func-test
   main-is:             FuncTest.hs
   hs-source-dirs:      func-test
   type:                exitcode-stdio-1.0
-  build-depends:       base 
+  build-depends:       base
                      , lsp-test
                      , lsp
                      , process

--- a/lsp-test/src/Language/LSP/Test/Session.hs
+++ b/lsp-test/src/Language/LSP/Test/Session.hs
@@ -40,8 +40,9 @@ import Control.Concurrent hiding (yield)
 import Control.Exception
 import Control.Lens hiding (List, Empty)
 import Control.Monad
-import Control.Monad.IO.Class
+import Control.Monad.Catch (MonadThrow)
 import Control.Monad.Except
+import Control.Monad.IO.Class
 #if __GLASGOW_HASKELL__ == 806
 import Control.Monad.Fail
 #endif
@@ -92,7 +93,7 @@ import Colog.Core (LogAction (..), WithSeverity (..), Severity (..))
 -- 'Language.LSP.Test.sendNotification'.
 
 newtype Session a = Session (ConduitParser FromServerMessage (StateT SessionState (ReaderT SessionContext IO)) a)
-  deriving (Functor, Applicative, Monad, MonadIO, Alternative)
+  deriving (Functor, Applicative, Monad, MonadIO, Alternative, MonadThrow)
 
 #if __GLASGOW_HASKELL__ >= 806
 instance MonadFail Session where


### PR DESCRIPTION
A `MonadThrow` instance is useful in the `Session` monad so that you can make assertions in various test frameworks.

This adds `exceptions` to the dependencies for `lsp-test`, but it's a pretty common dependency (already used in `lsp`).