### PR TITLE
lsp-test: export runSessionWithConfig' to allow modifying the CreateProcess

### DIFF
--- a/lsp-test/src/Language/LSP/Test.hs
+++ b/lsp-test/src/Language/LSP/Test.hs
@@ -781,7 +781,7 @@ getSemanticTokens :: TextDocumentIdentifier -> Session (Maybe SemanticTokens)
 getSemanticTokens doc = do
   let params = SemanticTokensParams Nothing Nothing doc
   rsp <- request STextDocumentSemanticTokensFull params
-  pure $ getResponseResult rsp 
+  pure $ getResponseResult rsp
 
 -- | Returns a list of capabilities that the server has requested to /dynamically/
 -- register during the 'Session'.

--- a/lsp-test/src/Language/LSP/Test.hs
+++ b/lsp-test/src/Language/LSP/Test.hs
@@ -162,8 +162,8 @@ runSessionWithConfig :: SessionConfig -- ^ Configuration options for the session
                      -> IO a
 runSessionWithConfig = runSessionWithConfigCustomProcess id
 
--- | Starts a new session with a custom configuration.
-runSessionWithConfigCustomProcess :: (CreateProcess -> CreateProcess) -- ^ Tweak the 'CreateProcess' used to start server.
+-- | Starts a new session with a custom configuration and server 'CreateProcess'.
+runSessionWithConfigCustomProcess :: (CreateProcess -> CreateProcess) -- ^ Tweak the 'CreateProcess' used to start the server.
                                   -> SessionConfig -- ^ Configuration options for the session.
                                   -> String -- ^ The command to run the server.
                                   -> C.ClientCapabilities -- ^ The capabilities that the client should declare.

--- a/lsp-test/src/Language/LSP/Test.hs
+++ b/lsp-test/src/Language/LSP/Test.hs
@@ -25,7 +25,7 @@ module Language.LSP.Test
     Session
   , runSession
   , runSessionWithConfig
-  , runSessionWithConfig'
+  , runSessionWithConfigCustomProcess
   , runSessionWithHandles
   , runSessionWithHandles'
   -- ** Config
@@ -160,17 +160,17 @@ runSessionWithConfig :: SessionConfig -- ^ Configuration options for the session
                      -> FilePath -- ^ The filepath to the root directory for the session.
                      -> Session a -- ^ The session to run.
                      -> IO a
-runSessionWithConfig = runSessionWithConfig' id
+runSessionWithConfig = runSessionWithConfigCustomProcess id
 
 -- | Starts a new session with a custom configuration.
-runSessionWithConfig' :: (CreateProcess -> CreateProcess)
-                      -> SessionConfig -- ^ Configuration options for the session.
-                      -> String -- ^ The command to run the server.
-                      -> C.ClientCapabilities -- ^ The capabilities that the client should declare.
-                      -> FilePath -- ^ The filepath to the root directory for the session.
-                      -> Session a -- ^ The session to run.
-                      -> IO a
-runSessionWithConfig' modifyCreateProcess config' serverExe caps rootDir session = do
+runSessionWithConfigCustomProcess :: (CreateProcess -> CreateProcess) -- ^ Tweak the 'CreateProcess' used to start server.
+                                  -> SessionConfig -- ^ Configuration options for the session.
+                                  -> String -- ^ The command to run the server.
+                                  -> C.ClientCapabilities -- ^ The capabilities that the client should declare.
+                                  -> FilePath -- ^ The filepath to the root directory for the session.
+                                  -> Session a -- ^ The session to run.
+                                  -> IO a
+runSessionWithConfigCustomProcess modifyCreateProcess config' serverExe caps rootDir session = do
   config <- envOverrideConfig config'
   withServer serverExe (logStdErr config) modifyCreateProcess $ \serverIn serverOut serverProc ->
     runSessionWithHandles' (Just serverProc) serverIn serverOut config caps rootDir session

--- a/lsp-test/src/Language/LSP/Test/Replay.hs
+++ b/lsp-test/src/Language/LSP/Test/Replay.hs
@@ -44,7 +44,7 @@ replaySession serverExe sessionDir = do
   -- decode session
   let unswappedEvents = map (fromJust . decode) entries
 
-  withServer serverExe False $ \serverIn serverOut serverProc -> do
+  withServer serverExe False id $ \serverIn serverOut serverProc -> do
 
     pid <- getProcessID serverProc
     events <- swapCommands pid <$> swapFiles sessionDir unswappedEvents

--- a/lsp-test/src/Language/LSP/Test/Server.hs
+++ b/lsp-test/src/Language/LSP/Test/Server.hs
@@ -6,13 +6,13 @@ import Language.LSP.Test.Compat
 import System.IO
 import System.Process hiding (withCreateProcess)
 
-withServer :: String -> Bool -> (Handle -> Handle -> ProcessHandle -> IO a) -> IO a
-withServer serverExe logStdErr f = do
+withServer :: String -> Bool -> (CreateProcess -> CreateProcess) -> (Handle -> Handle -> ProcessHandle -> IO a) -> IO a
+withServer serverExe logStdErr modifyCreateProcess f = do
   -- TODO Probably should just change runServer to accept
   -- separate command and arguments
   let cmd:args = words serverExe
       createProc = (proc cmd args) { std_in = CreatePipe, std_out = CreatePipe, std_err = CreatePipe }
-  withCreateProcess createProc $ \(Just serverIn) (Just serverOut) (Just serverErr) serverProc -> do
+  withCreateProcess (modifyCreateProcess createProc) $ \(Just serverIn) (Just serverOut) (Just serverErr) serverProc -> do
     -- Need to continuously consume to stderr else it gets blocked
     -- Can't pass NoStream either to std_err
     hSetBuffering serverErr NoBuffering


### PR DESCRIPTION
The default `runSessionWithConfig` launches an LSP server process, but doesn't provide any flexibility for modifying the `CreateProcess` to be used. This prevented me from doing things like tweaking the environment variables for the process.

This PR exports a new function `runSessionWithConfig'`, where the first argument allows the caller to modify the `CreateProcess`.