### PR TITLE
add post jobs to github workflows

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -49,3 +49,14 @@ jobs:
     - if: matrix.ghc == '8.10.7' && runner.os == 'Linux'
       name: Build using stack
       run: stack build
+
+  haskell_post_job:
+    runs-on: ubuntu-latest
+    needs: [ build ]
+    steps:
+      - run: |
+          echo "jobs info: ${{ toJSON(needs) }}"
+      - if: contains(needs.*.result, 'failure')
+        run: exit 1
+      - if: contains(needs.*.result, 'cancelled') && needs.pre_job.outputs.should_skip != 'true'
+        run: exit 1

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -19,3 +19,13 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - run: nix-shell --run "cabal update && cabal build all"
+  nix_post_job:
+    runs-on: ubuntu-latest
+    needs: [ nix ]
+    steps:
+      - run: |
+          echo "jobs info: ${{ toJSON(needs) }}"
+      - if: contains(needs.*.result, 'failure')
+        run: exit 1
+      - if: contains(needs.*.result, 'cancelled') && needs.pre_job.outputs.should_skip != 'true'
+        run: exit 1

--- a/cabal.project
+++ b/cabal.project
@@ -10,3 +10,6 @@ tests: True
 benchmarks: True
 test-show-details: direct
 haddock-quickjump: True
+
+-- https://github.com/TomMD/entropy/issues/75
+constraints: entropy < 0.4.1.9


### PR DESCRIPTION
Mergify relies on branch protection settings, which can only be configured here:
<img width="499" alt="image" src="https://user-images.githubusercontent.com/16440269/186063946-787ed602-302b-41c3-ad80-992982e380f6.png">

When a PR changes the test matrix, Mergify will still wait for the old jobs that no longer exist. See #446 for an example.

HLS repo [uses post jobs for each workflow and sets branch protection rules to wait for those post jobs](https://github.com/haskell/haskell-language-server/pull/3117/checks?check_run_id=7942452334).
