### PR TITLE
spec compliance: _registerOptions should be a Maybe

### DIFF
--- a/lsp-test/src/Language/LSP/Test.hs
+++ b/lsp-test/src/Language/LSP/Test.hs
@@ -430,7 +430,7 @@ createDoc file languageId contents = do
       createHits (WatchKind create _ _) = create
 
       regHits :: Registration WorkspaceDidChangeWatchedFiles -> Bool
-      regHits reg = foldl' (\acc w -> acc || watchHits w) False (reg ^. registerOptions . watchers)
+      regHits reg = foldl' (\acc w -> acc || watchHits w) False (reg ^. registerOptions . _Just . watchers)
 
       clientCapsSupports =
           caps ^? workspace . _Just . didChangeWatchedFiles . _Just . dynamicRegistration . _Just

--- a/lsp-test/test/Test.hs
+++ b/lsp-test/test/Test.hs
@@ -370,8 +370,8 @@ main = hspec $ around withDummyServer $ do
       liftIO $ do
         case regMethod `mEqClient` SWorkspaceDidChangeWatchedFiles of
           Just (Right HRefl) ->
-            regOpts `shouldBe` (DidChangeWatchedFilesRegistrationOptions $ List
-                                [ FileSystemWatcher "*.watch" (Just (WatchKind True True True)) ])
+            regOpts `shouldBe` (Just (DidChangeWatchedFilesRegistrationOptions $ List
+                                      [ FileSystemWatcher "*.watch" (Just (WatchKind True True True)) ]))
           _ -> expectationFailure "Registration wasn't on workspace/didChangeWatchedFiles"
 
       -- now unregister it by sending a specific createDoc

--- a/lsp-types/src/Language/LSP/Types/Registration.hs
+++ b/lsp-types/src/Language/LSP/Types/Registration.hs
@@ -111,7 +111,7 @@ data Registration (m :: Method FromClient t) =
     , _method :: SClientMethod m
       -- | Options necessary for the registration.
       -- Make this strict to aid the pattern matching exhaustiveness checker
-    , _registerOptions :: !(RegistrationOptions m)
+    , _registerOptions :: !(Maybe (RegistrationOptions m))
     }
   deriving Generic
 

--- a/lsp-types/test/ServerCapabilitiesSpec.hs
+++ b/lsp-types/test/ServerCapabilitiesSpec.hs
@@ -34,7 +34,7 @@ spec = describe "server capabilities" $ do
           Just registrationParams = decode input :: Maybe RegistrationParams
         in registrationParams ^. registrations `shouldBe`
              List [SomeRegistration $ Registration "4a56f5ca-7188-4f4c-a366-652d6f9d63aa"
-                                      SWorkspaceDidChangeConfiguration Empty]
+                                      SWorkspaceDidChangeConfiguration (Just Empty)]
   where
     documentFilters = List [DocumentFilter (Just "haskell") Nothing Nothing]
     documentFiltersJson = "[{\"language\": \"haskell\"}]"

--- a/lsp/src/Language/LSP/Server/Core.hs
+++ b/lsp/src/Language/LSP/Server/Core.hs
@@ -503,7 +503,7 @@ registerCapability method regOpts f = do
       -- First, check to see if the client supports dynamic registration on this method
       | dynamicSupported clientCaps = do
           uuid <- liftIO $ UUID.toText <$> getStdRandom random
-          let registration = J.Registration uuid method regOpts
+          let registration = J.Registration uuid method (Just regOpts)
               params = J.RegistrationParams (J.List [J.SomeRegistration registration])
               regId = RegistrationId uuid
           rio <- askUnliftIO


### PR DESCRIPTION
Another spec compliance issue. Spec is here: https://microsoft.github.io//language-server-protocol/specifications/lsp/3.17/specification/#client_registerCapability

(Any luck with the metamodel project @michaelpj?)