### PR TITLE
Add Ord instance for some types

### DIFF
--- a/lsp-types/src/Language/LSP/Types/CallHierarchy.hs
+++ b/lsp-types/src/Language/LSP/Types/CallHierarchy.hs
@@ -56,7 +56,7 @@ data CallHierarchyItem =
     -- prepare and incoming calls or outgoing calls requests.
     , _xdata :: Maybe Value
     }
-    deriving (Show, Read, Eq)
+    deriving (Show, Read, Eq, Ord)
 deriveJSON lspOptions ''CallHierarchyItem
 
 -- -------------------------------------
@@ -76,7 +76,7 @@ data CallHierarchyIncomingCall =
     -- denoted by @_from@.
     , _fromRanges :: List Range
     }
-    deriving (Show, Read, Eq)
+    deriving (Show, Read, Eq, Ord)
 deriveJSON lspOptions ''CallHierarchyIncomingCall
 
 -- -------------------------------------
@@ -96,5 +96,5 @@ data CallHierarchyOutgoingCall =
     -- the caller, e.g the item passed to `callHierarchy/outgoingCalls` request.
     , _fromRanges :: List Range
     }
-    deriving (Show, Read, Eq)
+    deriving (Show, Read, Eq, Ord)
 deriveJSON lspOptions ''CallHierarchyOutgoingCall

--- a/lsp-types/src/Language/LSP/Types/DocumentSymbol.hs
+++ b/lsp-types/src/Language/LSP/Types/DocumentSymbol.hs
@@ -65,7 +65,7 @@ data SymbolKind
     | SkOperator
     | SkTypeParameter
     | SkUnknown Scientific
-    deriving (Read,Show,Eq)
+    deriving (Read,Show,Eq, Ord)
 
 instance ToJSON SymbolKind where
   toJSON SkFile          = Number 1
@@ -134,7 +134,7 @@ Symbol tags are extra annotations that tweak the rendering of a symbol.
 data SymbolTag =
   StDeprecated -- ^ Render a symbol as obsolete, usually using a strike-out.
   | StUnknown Scientific
-  deriving (Read, Show, Eq)
+  deriving (Read, Show, Eq, Ord)
 
 instance ToJSON SymbolTag where
   toJSON StDeprecated          = Number 1


### PR DESCRIPTION
These instances are used in hls.

https://github.com/haskell/haskell-language-server/blob/master/plugins/hls-call-hierarchy-plugin/src/Ide/Plugin/CallHierarchy/Internal.hs#L191-L193

https://github.com/haskell/haskell-language-server/blob/master/plugins/hls-call-hierarchy-plugin/test/Main.hs#L423-L424