### PR TITLE
Add `curry-language-server` to the list of examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ typescript definitions laid out in the specification
 - [haskell-language-server](https://github.com/haskell/haskell-language-server)
 - [dhall-lsp-server](https://github.com/dhall-lang/dhall-haskell/tree/master/dhall-lsp-server#readme)
 - [swarm](https://github.com/byorgey/swarm/blob/main/src/Swarm/Language/LSP.hs)
+- [curry-language-server](https://github.com/fwcd/curry-language-server)
 
 ## Example language servers
 There are two example language servers in the `lsp/example/` folder. `Simple.hs` provides a minimal example:


### PR DESCRIPTION
[`curry-language-server`](https://github.com/fwcd/curry-language-server) is a language server for the functional logic language [Curry](https://en.wikipedia.org/wiki/Curry_(programming_language)).