### PR TITLE
Fix parsing of registerOptions

### DIFF
--- a/lsp-types/src/Language/LSP/Types/Registration.hs
+++ b/lsp-types/src/Language/LSP/Types/Registration.hs
@@ -138,7 +138,7 @@ instance ToJSON SomeRegistration where
 instance FromJSON SomeRegistration where
   parseJSON = withObject "Registration" $ \o -> do
     SomeClientMethod m <- o .: "method"
-    r <- Registration <$> o .: "id" <*> pure m <*> regHelper m (o .: "registerOptions")
+    r <- Registration <$> o .: "id" <*> pure m <*> regHelper m (o .:? "registerOptions")
     pure (SomeRegistration r)
 
 instance Eq SomeRegistration where


### PR DESCRIPTION
This field is supposed to be optional, so I added a question mark. Without this change, the parse fails when the field is absent.