### PR TITLE
fix backslash escaping

### DIFF
--- a/lsp/src/Language/LSP/Server/Core.hs
+++ b/lsp/src/Language/LSP/Server/Core.hs
@@ -114,8 +114,8 @@ data LanguageContextEnv config =
 --
 -- @
 -- mconcat [
---   notificationHandler SInitialized $ \notif -> pure ()
--- , requestHandler STextDocumentHover $ \req responder -> pure ()
+--   notificationHandler SInitialized $ \\notif -> pure ()
+-- , requestHandler STextDocumentHover $ \\req responder -> pure ()
 -- ]
 -- @
 data Handlers m


### PR DESCRIPTION
Current documentation is missing the backslash:
![image](https://user-images.githubusercontent.com/261693/211129884-656c6685-ca74-4c03-be4f-f1e1eb45c337.png)
