### PR TITLE
fix misplaced docstring

### DIFF
--- a/lsp-types/src/Language/LSP/Types/CodeAction.hs
+++ b/lsp-types/src/Language/LSP/Types/CodeAction.hs
@@ -251,7 +251,8 @@ data CodeAction =
     --
     -- Since LSP 3.15.0
     _isPreferred :: Maybe Bool,
-    _disabled    :: Maybe Reason, -- ^ Marks that the code action cannot currently be applied.
+    -- | Marks that the code action cannot currently be applied.
+    _disabled    :: Maybe Reason,
     -- | The workspace edit this code action performs.
     _edit :: Maybe WorkspaceEdit,
     -- | A command this code action executes. If a code action


### PR DESCRIPTION
Currently the `_edit` docstring is bunched up with `_disabled`:
https://hackage.haskell.org/package/lsp-types-1.6.0.0/docs/Language-LSP-Types.html#t:CodeAction

![Screenshot from 2023-01-24 19-16-56](https://user-images.githubusercontent.com/261693/214472821-d437aa12-91ef-4c58-a6f8-44ce88a14021.png)
