### PR TITLE
Fix ospath doesn't build

### DIFF
--- a/lsp-types/lsp-types.cabal
+++ b/lsp-types/lsp-types.cabal
@@ -74,6 +74,7 @@ library
     , deepseq
     , Diff              >=0.2
     , dlist
+    , exceptions
     , hashable
     , lens              >=4.15.2
     , mod

--- a/lsp-types/src/Language/LSP/Protocol/Types/Uri/OsPath.hs
+++ b/lsp-types/src/Language/LSP/Protocol/Types/Uri/OsPath.hs
@@ -19,7 +19,7 @@ module Language.LSP.Protocol.Types.Uri.OsPath
 import           Control.Exception      hiding (try)
 import           Control.Monad.Catch
 import           GHC.IO.Encoding        (getFileSystemEncoding)
-import           Language.LSP.Types.Uri
+import           Language.LSP.Protocol.Types.Uri
 import           System.IO
 import           System.IO.Unsafe       (unsafePerformIO)
 import           System.OsPath


### PR DESCRIPTION
This is needed when hls is build wih 9.6.*