### PR TITLE
Don't deprecate fields

### DIFF
--- a/lsp-types/ChangeLog.md
+++ b/lsp-types/ChangeLog.md
@@ -1,5 +1,13 @@
 # Revision history for lsp-types
 
+## 2.0.0.2
+
+* Removed deprecation pragmas from fields, as these cannot currently be avoided.
+
+## 2.0.0.1
+
+* Fixed missing `extra-source-files` for `metamodel.json`.
+
 ## 2.0.0.0
 
 * Breaking change: major restructure to generate types and methods from the LSP metamodel.

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CompletionItem.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CompletionItem.hs
@@ -24,7 +24,6 @@ import qualified Language.LSP.Protocol.Internal.Types.MarkupContent
 import qualified Language.LSP.Protocol.Internal.Types.TextEdit
 import qualified Language.LSP.Protocol.Types.Common
 
-{-# DEPRECATED _deprecated "Use `tags` instead." #-}
 {-|
 A completion item represents a text snippet that is
 proposed to complete text that is being typed.

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentSymbol.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentSymbol.hs
@@ -17,7 +17,6 @@ import qualified Language.LSP.Protocol.Internal.Types.SymbolKind
 import qualified Language.LSP.Protocol.Internal.Types.SymbolTag
 import qualified Language.LSP.Protocol.Types.Common
 
-{-# DEPRECATED _deprecated "Use tags instead" #-}
 {-|
 Represents programming constructs like variables, classes, interfaces etc.
 that appear in a document. Document symbols can be hierarchical and they

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InitializeParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InitializeParams.hs
@@ -21,8 +21,6 @@ import qualified Language.LSP.Protocol.Internal.Types.WorkspaceFolder
 import qualified Language.LSP.Protocol.Types.Common
 import qualified Language.LSP.Protocol.Types.Uri
 
-{-# DEPRECATED _rootPath "in favour of rootUri." #-}
-{-# DEPRECATED _rootUri "in favour of workspaceFolders." #-}
 {-|
 
 -}

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SymbolInformation.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SymbolInformation.hs
@@ -17,7 +17,6 @@ import qualified Language.LSP.Protocol.Internal.Types.SymbolKind
 import qualified Language.LSP.Protocol.Internal.Types.SymbolTag
 import qualified Language.LSP.Protocol.Types.Common
 
-{-# DEPRECATED _deprecated "Use tags instead" #-}
 {-|
 Represents information about programming constructs like variables, classes,
 interfaces etc.

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/UInitializeParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/UInitializeParams.hs
@@ -20,8 +20,6 @@ import qualified Language.LSP.Protocol.Internal.Types.TraceValues
 import qualified Language.LSP.Protocol.Types.Common
 import qualified Language.LSP.Protocol.Types.Uri
 
-{-# DEPRECATED _rootPath "in favour of rootUri." #-}
-{-# DEPRECATED _rootUri "in favour of workspaceFolders." #-}
 {-|
 The initialize parameters
 -}

--- a/lsp-types/generator/CodeGen.hs
+++ b/lsp-types/generator/CodeGen.hs
@@ -295,8 +295,12 @@ printStruct tn s@Structure{name, documentation, since, proposed, deprecated} = d
       propDoc <- multilineHaddock . pretty <$> mkDocumentation documentation since proposed
       pure $ hardvcat [propDoc, pretty n <+> "::" <+> mty]
 
-  -- Annoyingly, this won't deprecate the lens, which is defined somewhere else entirely. Unclear what to do about that.
-  let deprecations = optDeprecated tn deprecated ++ (flip concatMap props $ \Property{name, deprecated} -> optDeprecated (makeFieldName name) deprecated)
+  -- We do *not* deprecate fields. We can't really represent this properly: typically a deprecated field
+  -- is optional, and the "correct" thing to do is to omit it. But in our representaiton that means passing
+  -- Nothing as the value, which counts as "using" the field. So there is no way for users to avoid the
+  -- deprecation warning, which is silly. To do this properly we'd need to do something clever with
+  -- pattern synonyms maybe?
+  let deprecations = optDeprecated tn deprecated
 
   ensureImport "GHC.Generics" Unqual
   ensureImport "Control.DeepSeq" Unqual

--- a/lsp-types/lsp-types.cabal
+++ b/lsp-types/lsp-types.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               lsp-types
-version:            2.0.0.1
+version:            2.0.0.2
 synopsis:
   Haskell library for the Microsoft Language Server Protocol, data types
 


### PR DESCRIPTION
As reported on IRC, this is silly since there's no way to avoid the deprecation warning.