### PR TITLE
Add lower bound constraint hashable >= 1.3.4.0

### DIFF
--- a/lsp-types/lsp-types.cabal
+++ b/lsp-types/lsp-types.cabal
@@ -77,7 +77,7 @@ library
     , Diff              >=0.2
     , dlist
     , exceptions
-    , hashable
+    , hashable          >=1.3.4.0
     , lens              >=4.15.2
     , mod
     , mtl               <2.4


### PR DESCRIPTION
This is necessary because the `Hashable` instance for `Map` was only added in `1.3.4.0`, and is relied on e.g. here:

https://github.com/haskell/lsp/blob/a1c7dff4ddd712887de5610153f34803611609d9/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceEdit.hs#L68