### PR TITLE
Add Pretty instances for LSP types

### DIFF
--- a/lsp-types/ChangeLog.md
+++ b/lsp-types/ChangeLog.md
@@ -1,5 +1,11 @@
 # Revision history for lsp-types
 
+## Unreleased
+
+- Add `Language.LSP.Protocol.Utils.Misc.prettyJSON :: Value -> Doc ann` for prettyprinting JSON, 
+  and `ViaJSON` as a deriving-via newtype wrapper for it.
+- Generate `Pretty` instances for all LSP types using `ViaJSON`.
+
 ## 2.0.1.1
 
 * Fix parsing of notifications with missing params

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/AnnotatedTextEdit.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/AnnotatedTextEdit.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.AnnotatedTextEdit where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -39,6 +41,7 @@ data AnnotatedTextEdit = AnnotatedTextEdit
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON AnnotatedTextEdit)
 
 instance Aeson.ToJSON AnnotatedTextEdit where
   toJSON (AnnotatedTextEdit arg0 arg1 arg2) = Aeson.object $ concat $  [["range" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ApplyWorkspaceEditParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ApplyWorkspaceEditParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ApplyWorkspaceEditParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -32,6 +34,7 @@ data ApplyWorkspaceEditParams = ApplyWorkspaceEditParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ApplyWorkspaceEditParams)
 
 instance Aeson.ToJSON ApplyWorkspaceEditParams where
   toJSON (ApplyWorkspaceEditParams arg0 arg1) = Aeson.object $ concat $  ["label" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ApplyWorkspaceEditResult.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ApplyWorkspaceEditResult.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ApplyWorkspaceEditResult where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -39,6 +41,7 @@ data ApplyWorkspaceEditResult = ApplyWorkspaceEditResult
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ApplyWorkspaceEditResult)
 
 instance Aeson.ToJSON ApplyWorkspaceEditResult where
   toJSON (ApplyWorkspaceEditResult arg0 arg1 arg2) = Aeson.object $ concat $  [["applied" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/BaseSymbolInformation.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/BaseSymbolInformation.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.BaseSymbolInformation where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -44,6 +46,7 @@ data BaseSymbolInformation = BaseSymbolInformation
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON BaseSymbolInformation)
 
 instance Aeson.ToJSON BaseSymbolInformation where
   toJSON (BaseSymbolInformation arg0 arg1 arg2 arg3) = Aeson.object $ concat $  [["name" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CallHierarchyClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CallHierarchyClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CallHierarchyClientCapabilities wher
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -26,6 +28,7 @@ data CallHierarchyClientCapabilities = CallHierarchyClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CallHierarchyClientCapabilities)
 
 instance Aeson.ToJSON CallHierarchyClientCapabilities where
   toJSON (CallHierarchyClientCapabilities arg0) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CallHierarchyIncomingCall.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CallHierarchyIncomingCall.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CallHierarchyIncomingCall where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -33,6 +35,7 @@ data CallHierarchyIncomingCall = CallHierarchyIncomingCall
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CallHierarchyIncomingCall)
 
 instance Aeson.ToJSON CallHierarchyIncomingCall where
   toJSON (CallHierarchyIncomingCall arg0 arg1) = Aeson.object $ concat $  [["from" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CallHierarchyIncomingCallsParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CallHierarchyIncomingCallsParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CallHierarchyIncomingCallsParams whe
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -37,6 +39,7 @@ data CallHierarchyIncomingCallsParams = CallHierarchyIncomingCallsParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CallHierarchyIncomingCallsParams)
 
 instance Aeson.ToJSON CallHierarchyIncomingCallsParams where
   toJSON (CallHierarchyIncomingCallsParams arg0 arg1 arg2) = Aeson.object $ concat $  ["workDoneToken" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CallHierarchyItem.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CallHierarchyItem.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CallHierarchyItem where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
@@ -63,6 +65,7 @@ data CallHierarchyItem = CallHierarchyItem
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CallHierarchyItem)
 
 instance Aeson.ToJSON CallHierarchyItem where
   toJSON (CallHierarchyItem arg0 arg1 arg2 arg3 arg4 arg5 arg6 arg7) = Aeson.object $ concat $  [["name" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CallHierarchyOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CallHierarchyOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CallHierarchyOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -26,6 +28,7 @@ data CallHierarchyOptions = CallHierarchyOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CallHierarchyOptions)
 
 instance Aeson.ToJSON CallHierarchyOptions where
   toJSON (CallHierarchyOptions arg0) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CallHierarchyOutgoingCall.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CallHierarchyOutgoingCall.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CallHierarchyOutgoingCall where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -34,6 +36,7 @@ data CallHierarchyOutgoingCall = CallHierarchyOutgoingCall
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CallHierarchyOutgoingCall)
 
 instance Aeson.ToJSON CallHierarchyOutgoingCall where
   toJSON (CallHierarchyOutgoingCall arg0 arg1) = Aeson.object $ concat $  [["to" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CallHierarchyOutgoingCallsParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CallHierarchyOutgoingCallsParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CallHierarchyOutgoingCallsParams whe
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -37,6 +39,7 @@ data CallHierarchyOutgoingCallsParams = CallHierarchyOutgoingCallsParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CallHierarchyOutgoingCallsParams)
 
 instance Aeson.ToJSON CallHierarchyOutgoingCallsParams where
   toJSON (CallHierarchyOutgoingCallsParams arg0 arg1 arg2) = Aeson.object $ concat $  ["workDoneToken" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CallHierarchyPrepareParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CallHierarchyPrepareParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CallHierarchyPrepareParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -37,6 +39,7 @@ data CallHierarchyPrepareParams = CallHierarchyPrepareParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CallHierarchyPrepareParams)
 
 instance Aeson.ToJSON CallHierarchyPrepareParams where
   toJSON (CallHierarchyPrepareParams arg0 arg1 arg2) = Aeson.object $ concat $  [["textDocument" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CallHierarchyRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CallHierarchyRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CallHierarchyRegistrationOptions whe
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -38,6 +40,7 @@ data CallHierarchyRegistrationOptions = CallHierarchyRegistrationOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CallHierarchyRegistrationOptions)
 
 instance Aeson.ToJSON CallHierarchyRegistrationOptions where
   toJSON (CallHierarchyRegistrationOptions arg0 arg1 arg2) = Aeson.object $ concat $  [["documentSelector" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CancelParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CancelParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CancelParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -25,6 +27,7 @@ data CancelParams = CancelParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CancelParams)
 
 instance Aeson.ToJSON CancelParams where
   toJSON (CancelParams arg0) = Aeson.object $ concat $  [["id" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ChangeAnnotation.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ChangeAnnotation.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ChangeAnnotation where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -38,6 +40,7 @@ data ChangeAnnotation = ChangeAnnotation
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ChangeAnnotation)
 
 instance Aeson.ToJSON ChangeAnnotation where
   toJSON (ChangeAnnotation arg0 arg1 arg2) = Aeson.object $ concat $  [["label" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ChangeAnnotationIdentifier.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ChangeAnnotationIdentifier.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ChangeAnnotationIdentifier where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -23,3 +25,4 @@ newtype ChangeAnnotationIdentifier = ChangeAnnotationIdentifier Data.Text.Text
   , Aeson.FromJSONKey )
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ChangeAnnotationIdentifier)

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ClientCapabilities where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
@@ -54,6 +56,7 @@ data ClientCapabilities = ClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ClientCapabilities)
 
 instance Aeson.ToJSON ClientCapabilities where
   toJSON (ClientCapabilities arg0 arg1 arg2 arg3 arg4 arg5) = Aeson.object $ concat $  ["workspace" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CodeAction.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CodeAction.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CodeAction where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson
 import qualified Data.Aeson as Aeson
 import qualified Data.Row as Row
@@ -89,6 +91,7 @@ data CodeAction = CodeAction
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CodeAction)
 
 instance Aeson.ToJSON CodeAction where
   toJSON (CodeAction arg0 arg1 arg2 arg3 arg4 arg5 arg6 arg7) = Aeson.object $ concat $  [["title" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CodeActionClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CodeActionClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CodeActionClientCapabilities where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row as Row
 import qualified Data.Row.Aeson as Aeson
@@ -72,6 +74,7 @@ data CodeActionClientCapabilities = CodeActionClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CodeActionClientCapabilities)
 
 instance Aeson.ToJSON CodeActionClientCapabilities where
   toJSON (CodeActionClientCapabilities arg0 arg1 arg2 arg3 arg4 arg5 arg6) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CodeActionContext.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CodeActionContext.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CodeActionContext where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -45,6 +47,7 @@ data CodeActionContext = CodeActionContext
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CodeActionContext)
 
 instance Aeson.ToJSON CodeActionContext where
   toJSON (CodeActionContext arg0 arg1 arg2) = Aeson.object $ concat $  [["diagnostics" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CodeActionKind.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CodeActionKind.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CodeActionKind where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -93,6 +95,7 @@ data CodeActionKind =
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON
   , Data.String.IsString ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum CodeActionKind Data.Text.Text)
+  deriving Pretty via (ViaJSON CodeActionKind)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum CodeActionKind where
   knownValues = Data.Set.fromList [CodeActionKind_Empty

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CodeActionOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CodeActionOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CodeActionOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -39,6 +41,7 @@ data CodeActionOptions = CodeActionOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CodeActionOptions)
 
 instance Aeson.ToJSON CodeActionOptions where
   toJSON (CodeActionOptions arg0 arg1 arg2) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CodeActionParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CodeActionParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CodeActionParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -45,6 +47,7 @@ data CodeActionParams = CodeActionParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CodeActionParams)
 
 instance Aeson.ToJSON CodeActionParams where
   toJSON (CodeActionParams arg0 arg1 arg2 arg3 arg4) = Aeson.object $ concat $  ["workDoneToken" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CodeActionRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CodeActionRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CodeActionRegistrationOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -45,6 +47,7 @@ data CodeActionRegistrationOptions = CodeActionRegistrationOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CodeActionRegistrationOptions)
 
 instance Aeson.ToJSON CodeActionRegistrationOptions where
   toJSON (CodeActionRegistrationOptions arg0 arg1 arg2 arg3) = Aeson.object $ concat $  [["documentSelector" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CodeActionTriggerKind.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CodeActionTriggerKind.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CodeActionTriggerKind where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -37,6 +39,7 @@ data CodeActionTriggerKind =
   deriving anyclass (NFData, Hashable)
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum CodeActionTriggerKind Language.LSP.Protocol.Types.Common.UInt)
+  deriving Pretty via (ViaJSON CodeActionTriggerKind)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum CodeActionTriggerKind where
   knownValues = Data.Set.fromList [CodeActionTriggerKind_Invoked

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CodeDescription.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CodeDescription.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CodeDescription where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -27,6 +29,7 @@ data CodeDescription = CodeDescription
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CodeDescription)
 
 instance Aeson.ToJSON CodeDescription where
   toJSON (CodeDescription arg0) = Aeson.object $ concat $  [["href" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CodeLens.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CodeLens.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CodeLens where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
@@ -40,6 +42,7 @@ data CodeLens = CodeLens
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CodeLens)
 
 instance Aeson.ToJSON CodeLens where
   toJSON (CodeLens arg0 arg1 arg2) = Aeson.object $ concat $  [["range" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CodeLensClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CodeLensClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CodeLensClientCapabilities where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -24,6 +26,7 @@ data CodeLensClientCapabilities = CodeLensClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CodeLensClientCapabilities)
 
 instance Aeson.ToJSON CodeLensClientCapabilities where
   toJSON (CodeLensClientCapabilities arg0) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CodeLensOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CodeLensOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CodeLensOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -28,6 +30,7 @@ data CodeLensOptions = CodeLensOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CodeLensOptions)
 
 instance Aeson.ToJSON CodeLensOptions where
   toJSON (CodeLensOptions arg0 arg1) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CodeLensParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CodeLensParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CodeLensParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -35,6 +37,7 @@ data CodeLensParams = CodeLensParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CodeLensParams)
 
 instance Aeson.ToJSON CodeLensParams where
   toJSON (CodeLensParams arg0 arg1 arg2) = Aeson.object $ concat $  ["workDoneToken" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CodeLensRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CodeLensRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CodeLensRegistrationOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -34,6 +36,7 @@ data CodeLensRegistrationOptions = CodeLensRegistrationOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CodeLensRegistrationOptions)
 
 instance Aeson.ToJSON CodeLensRegistrationOptions where
   toJSON (CodeLensRegistrationOptions arg0 arg1 arg2) = Aeson.object $ concat $  [["documentSelector" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CodeLensWorkspaceClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CodeLensWorkspaceClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CodeLensWorkspaceClientCapabilities 
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -30,6 +32,7 @@ data CodeLensWorkspaceClientCapabilities = CodeLensWorkspaceClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CodeLensWorkspaceClientCapabilities)
 
 instance Aeson.ToJSON CodeLensWorkspaceClientCapabilities where
   toJSON (CodeLensWorkspaceClientCapabilities arg0) = Aeson.object $ concat $  ["refreshSupport" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/Color.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/Color.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.Color where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -36,6 +38,7 @@ data Color = Color
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON Color)
 
 instance Aeson.ToJSON Color where
   toJSON (Color arg0 arg1 arg2 arg3) = Aeson.object $ concat $  [["red" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ColorInformation.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ColorInformation.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ColorInformation where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -30,6 +32,7 @@ data ColorInformation = ColorInformation
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ColorInformation)
 
 instance Aeson.ToJSON ColorInformation where
   toJSON (ColorInformation arg0 arg1) = Aeson.object $ concat $  [["range" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ColorPresentation.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ColorPresentation.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ColorPresentation where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -39,6 +41,7 @@ data ColorPresentation = ColorPresentation
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ColorPresentation)
 
 instance Aeson.ToJSON ColorPresentation where
   toJSON (ColorPresentation arg0 arg1 arg2) = Aeson.object $ concat $  [["label" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ColorPresentationParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ColorPresentationParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ColorPresentationParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -45,6 +47,7 @@ data ColorPresentationParams = ColorPresentationParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ColorPresentationParams)
 
 instance Aeson.ToJSON ColorPresentationParams where
   toJSON (ColorPresentationParams arg0 arg1 arg2 arg3 arg4) = Aeson.object $ concat $  ["workDoneToken" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/Command.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/Command.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.Command where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
@@ -38,6 +40,7 @@ data Command = Command
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON Command)
 
 instance Aeson.ToJSON Command where
   toJSON (Command arg0 arg1 arg2) = Aeson.object $ concat $  [["title" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CompletionClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CompletionClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CompletionClientCapabilities where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row as Row
 import qualified Data.Row.Aeson as Aeson
@@ -59,6 +61,7 @@ data CompletionClientCapabilities = CompletionClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CompletionClientCapabilities)
 
 instance Aeson.ToJSON CompletionClientCapabilities where
   toJSON (CompletionClientCapabilities arg0 arg1 arg2 arg3 arg4 arg5) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CompletionContext.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CompletionContext.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CompletionContext where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -31,6 +33,7 @@ data CompletionContext = CompletionContext
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CompletionContext)
 
 instance Aeson.ToJSON CompletionContext where
   toJSON (CompletionContext arg0 arg1) = Aeson.object $ concat $  [["triggerKind" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CompletionItem.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CompletionItem.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CompletionItem where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
@@ -187,6 +189,7 @@ data CompletionItem = CompletionItem
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CompletionItem)
 
 instance Aeson.ToJSON CompletionItem where
   toJSON (CompletionItem arg0 arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14 arg15 arg16 arg17 arg18) = Aeson.object $ concat $  [["label" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CompletionItemKind.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CompletionItemKind.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CompletionItemKind where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -124,6 +126,7 @@ data CompletionItemKind =
   deriving anyclass (NFData, Hashable)
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum CompletionItemKind Language.LSP.Protocol.Types.Common.UInt)
+  deriving Pretty via (ViaJSON CompletionItemKind)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum CompletionItemKind where
   knownValues = Data.Set.fromList [CompletionItemKind_Text

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CompletionItemLabelDetails.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CompletionItemLabelDetails.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CompletionItemLabelDetails where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -33,6 +35,7 @@ data CompletionItemLabelDetails = CompletionItemLabelDetails
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CompletionItemLabelDetails)
 
 instance Aeson.ToJSON CompletionItemLabelDetails where
   toJSON (CompletionItemLabelDetails arg0 arg1) = Aeson.object $ concat $  ["detail" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CompletionItemTag.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CompletionItemTag.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CompletionItemTag where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -31,6 +33,7 @@ data CompletionItemTag =
   deriving anyclass (NFData, Hashable)
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum CompletionItemTag Language.LSP.Protocol.Types.Common.UInt)
+  deriving Pretty via (ViaJSON CompletionItemTag)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum CompletionItemTag where
   knownValues = Data.Set.fromList [CompletionItemTag_Deprecated]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CompletionList.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CompletionList.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CompletionList where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson
 import qualified Data.Aeson as Aeson
 import qualified Data.Row as Row
@@ -55,6 +57,7 @@ data CompletionList = CompletionList
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CompletionList)
 
 instance Aeson.ToJSON CompletionList where
   toJSON (CompletionList arg0 arg1 arg2) = Aeson.object $ concat $  [["isIncomplete" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CompletionOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CompletionOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CompletionOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row as Row
 import qualified Data.Row.Aeson as Aeson
@@ -60,6 +62,7 @@ data CompletionOptions = CompletionOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CompletionOptions)
 
 instance Aeson.ToJSON CompletionOptions where
   toJSON (CompletionOptions arg0 arg1 arg2 arg3 arg4) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CompletionParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CompletionParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CompletionParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -46,6 +48,7 @@ data CompletionParams = CompletionParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CompletionParams)
 
 instance Aeson.ToJSON CompletionParams where
   toJSON (CompletionParams arg0 arg1 arg2 arg3 arg4) = Aeson.object $ concat $  [["textDocument" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CompletionRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CompletionRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CompletionRegistrationOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row as Row
 import qualified Data.Row.Aeson as Aeson
@@ -66,6 +68,7 @@ data CompletionRegistrationOptions = CompletionRegistrationOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CompletionRegistrationOptions)
 
 instance Aeson.ToJSON CompletionRegistrationOptions where
   toJSON (CompletionRegistrationOptions arg0 arg1 arg2 arg3 arg4 arg5) = Aeson.object $ concat $  [["documentSelector" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CompletionTriggerKind.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CompletionTriggerKind.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CompletionTriggerKind where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -38,6 +40,7 @@ data CompletionTriggerKind =
   deriving anyclass (NFData, Hashable)
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum CompletionTriggerKind Language.LSP.Protocol.Types.Common.UInt)
+  deriving Pretty via (ViaJSON CompletionTriggerKind)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum CompletionTriggerKind where
   knownValues = Data.Set.fromList [CompletionTriggerKind_Invoked

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ConfigurationItem.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ConfigurationItem.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ConfigurationItem where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -29,6 +31,7 @@ data ConfigurationItem = ConfigurationItem
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ConfigurationItem)
 
 instance Aeson.ToJSON ConfigurationItem where
   toJSON (ConfigurationItem arg0 arg1) = Aeson.object $ concat $  ["scopeUri" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ConfigurationParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ConfigurationParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ConfigurationParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -25,6 +27,7 @@ data ConfigurationParams = ConfigurationParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ConfigurationParams)
 
 instance Aeson.ToJSON ConfigurationParams where
   toJSON (ConfigurationParams arg0) = Aeson.object $ concat $  [["items" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CreateFile.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CreateFile.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CreateFile where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -42,6 +44,7 @@ data CreateFile = CreateFile
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CreateFile)
 
 instance Aeson.ToJSON CreateFile where
   toJSON (CreateFile arg0 arg1 arg2 arg3) = Aeson.object $ concat $  ["annotationId" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CreateFileOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CreateFileOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CreateFileOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -28,6 +30,7 @@ data CreateFileOptions = CreateFileOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CreateFileOptions)
 
 instance Aeson.ToJSON CreateFileOptions where
   toJSON (CreateFileOptions arg0 arg1) = Aeson.object $ concat $  ["overwrite" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CreateFilesParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/CreateFilesParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.CreateFilesParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -28,6 +30,7 @@ data CreateFilesParams = CreateFilesParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON CreateFilesParams)
 
 instance Aeson.ToJSON CreateFilesParams where
   toJSON (CreateFilesParams arg0) = Aeson.object $ concat $  [["files" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/Declaration.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/Declaration.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.Declaration where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -21,3 +23,4 @@ newtype Declaration = Declaration (Language.LSP.Protocol.Internal.Types.Location
   deriving newtype (Aeson.ToJSON, Aeson.FromJSON)
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON Declaration)

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DeclarationClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DeclarationClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DeclarationClientCapabilities where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -30,6 +32,7 @@ data DeclarationClientCapabilities = DeclarationClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DeclarationClientCapabilities)
 
 instance Aeson.ToJSON DeclarationClientCapabilities where
   toJSON (DeclarationClientCapabilities arg0 arg1) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DeclarationLink.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DeclarationLink.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DeclarationLink where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -26,3 +28,4 @@ newtype DeclarationLink = DeclarationLink Language.LSP.Protocol.Internal.Types.L
   deriving newtype (Aeson.ToJSON, Aeson.FromJSON)
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DeclarationLink)

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DeclarationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DeclarationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DeclarationOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -24,6 +26,7 @@ data DeclarationOptions = DeclarationOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DeclarationOptions)
 
 instance Aeson.ToJSON DeclarationOptions where
   toJSON (DeclarationOptions arg0) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DeclarationParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DeclarationParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DeclarationParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -40,6 +42,7 @@ data DeclarationParams = DeclarationParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DeclarationParams)
 
 instance Aeson.ToJSON DeclarationParams where
   toJSON (DeclarationParams arg0 arg1 arg2 arg3) = Aeson.object $ concat $  [["textDocument" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DeclarationRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DeclarationRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DeclarationRegistrationOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -36,6 +38,7 @@ data DeclarationRegistrationOptions = DeclarationRegistrationOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DeclarationRegistrationOptions)
 
 instance Aeson.ToJSON DeclarationRegistrationOptions where
   toJSON (DeclarationRegistrationOptions arg0 arg1 arg2) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/Definition.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/Definition.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.Definition where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -26,3 +28,4 @@ newtype Definition = Definition (Language.LSP.Protocol.Internal.Types.Location.L
   deriving newtype (Aeson.ToJSON, Aeson.FromJSON)
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON Definition)

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DefinitionClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DefinitionClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DefinitionClientCapabilities where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -30,6 +32,7 @@ data DefinitionClientCapabilities = DefinitionClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DefinitionClientCapabilities)
 
 instance Aeson.ToJSON DefinitionClientCapabilities where
   toJSON (DefinitionClientCapabilities arg0 arg1) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DefinitionLink.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DefinitionLink.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DefinitionLink where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -23,3 +25,4 @@ newtype DefinitionLink = DefinitionLink Language.LSP.Protocol.Internal.Types.Loc
   deriving newtype (Aeson.ToJSON, Aeson.FromJSON)
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DefinitionLink)

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DefinitionOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DefinitionOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DefinitionOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -24,6 +26,7 @@ data DefinitionOptions = DefinitionOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DefinitionOptions)
 
 instance Aeson.ToJSON DefinitionOptions where
   toJSON (DefinitionOptions arg0) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DefinitionParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DefinitionParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DefinitionParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -40,6 +42,7 @@ data DefinitionParams = DefinitionParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DefinitionParams)
 
 instance Aeson.ToJSON DefinitionParams where
   toJSON (DefinitionParams arg0 arg1 arg2 arg3) = Aeson.object $ concat $  [["textDocument" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DefinitionRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DefinitionRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DefinitionRegistrationOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -30,6 +32,7 @@ data DefinitionRegistrationOptions = DefinitionRegistrationOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DefinitionRegistrationOptions)
 
 instance Aeson.ToJSON DefinitionRegistrationOptions where
   toJSON (DefinitionRegistrationOptions arg0 arg1) = Aeson.object $ concat $  [["documentSelector" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DeleteFile.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DeleteFile.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DeleteFile where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -42,6 +44,7 @@ data DeleteFile = DeleteFile
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DeleteFile)
 
 instance Aeson.ToJSON DeleteFile where
   toJSON (DeleteFile arg0 arg1 arg2 arg3) = Aeson.object $ concat $  ["annotationId" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DeleteFileOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DeleteFileOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DeleteFileOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -28,6 +30,7 @@ data DeleteFileOptions = DeleteFileOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DeleteFileOptions)
 
 instance Aeson.ToJSON DeleteFileOptions where
   toJSON (DeleteFileOptions arg0 arg1) = Aeson.object $ concat $  ["recursive" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DeleteFilesParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DeleteFilesParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DeleteFilesParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -28,6 +30,7 @@ data DeleteFilesParams = DeleteFilesParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DeleteFilesParams)
 
 instance Aeson.ToJSON DeleteFilesParams where
   toJSON (DeleteFilesParams arg0) = Aeson.object $ concat $  [["files" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/Diagnostic.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/Diagnostic.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.Diagnostic where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
@@ -76,6 +78,7 @@ data Diagnostic = Diagnostic
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON Diagnostic)
 
 instance Aeson.ToJSON Diagnostic where
   toJSON (Diagnostic arg0 arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8) = Aeson.object $ concat $  [["range" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DiagnosticClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DiagnosticClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DiagnosticClientCapabilities where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -32,6 +34,7 @@ data DiagnosticClientCapabilities = DiagnosticClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DiagnosticClientCapabilities)
 
 instance Aeson.ToJSON DiagnosticClientCapabilities where
   toJSON (DiagnosticClientCapabilities arg0 arg1) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DiagnosticOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DiagnosticOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DiagnosticOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -43,6 +45,7 @@ data DiagnosticOptions = DiagnosticOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DiagnosticOptions)
 
 instance Aeson.ToJSON DiagnosticOptions where
   toJSON (DiagnosticOptions arg0 arg1 arg2 arg3) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DiagnosticRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DiagnosticRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DiagnosticRegistrationOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -54,6 +56,7 @@ data DiagnosticRegistrationOptions = DiagnosticRegistrationOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DiagnosticRegistrationOptions)
 
 instance Aeson.ToJSON DiagnosticRegistrationOptions where
   toJSON (DiagnosticRegistrationOptions arg0 arg1 arg2 arg3 arg4 arg5) = Aeson.object $ concat $  [["documentSelector" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DiagnosticRelatedInformation.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DiagnosticRelatedInformation.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DiagnosticRelatedInformation where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -32,6 +34,7 @@ data DiagnosticRelatedInformation = DiagnosticRelatedInformation
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DiagnosticRelatedInformation)
 
 instance Aeson.ToJSON DiagnosticRelatedInformation where
   toJSON (DiagnosticRelatedInformation arg0 arg1) = Aeson.object $ concat $  [["location" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DiagnosticServerCancellationData.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DiagnosticServerCancellationData.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DiagnosticServerCancellationData whe
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -26,6 +28,7 @@ data DiagnosticServerCancellationData = DiagnosticServerCancellationData
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DiagnosticServerCancellationData)
 
 instance Aeson.ToJSON DiagnosticServerCancellationData where
   toJSON (DiagnosticServerCancellationData arg0) = Aeson.object $ concat $  [["retriggerRequest" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DiagnosticSeverity.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DiagnosticSeverity.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DiagnosticSeverity where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -40,6 +42,7 @@ data DiagnosticSeverity =
   deriving anyclass (NFData, Hashable)
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum DiagnosticSeverity Language.LSP.Protocol.Types.Common.UInt)
+  deriving Pretty via (ViaJSON DiagnosticSeverity)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum DiagnosticSeverity where
   knownValues = Data.Set.fromList [DiagnosticSeverity_Error

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DiagnosticTag.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DiagnosticTag.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DiagnosticTag where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -39,6 +41,7 @@ data DiagnosticTag =
   deriving anyclass (NFData, Hashable)
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum DiagnosticTag Language.LSP.Protocol.Types.Common.UInt)
+  deriving Pretty via (ViaJSON DiagnosticTag)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum DiagnosticTag where
   knownValues = Data.Set.fromList [DiagnosticTag_Unnecessary

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DiagnosticWorkspaceClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DiagnosticWorkspaceClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DiagnosticWorkspaceClientCapabilitie
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -32,6 +34,7 @@ data DiagnosticWorkspaceClientCapabilities = DiagnosticWorkspaceClientCapabiliti
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DiagnosticWorkspaceClientCapabilities)
 
 instance Aeson.ToJSON DiagnosticWorkspaceClientCapabilities where
   toJSON (DiagnosticWorkspaceClientCapabilities arg0) = Aeson.object $ concat $  ["refreshSupport" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DidChangeConfigurationClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DidChangeConfigurationClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DidChangeConfigurationClientCapabili
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -24,6 +26,7 @@ data DidChangeConfigurationClientCapabilities = DidChangeConfigurationClientCapa
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DidChangeConfigurationClientCapabilities)
 
 instance Aeson.ToJSON DidChangeConfigurationClientCapabilities where
   toJSON (DidChangeConfigurationClientCapabilities arg0) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DidChangeConfigurationParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DidChangeConfigurationParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DidChangeConfigurationParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
@@ -25,6 +27,7 @@ data DidChangeConfigurationParams = DidChangeConfigurationParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DidChangeConfigurationParams)
 
 instance Aeson.ToJSON DidChangeConfigurationParams where
   toJSON (DidChangeConfigurationParams arg0) = Aeson.object $ concat $  [["settings" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DidChangeConfigurationRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DidChangeConfigurationRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DidChangeConfigurationRegistrationOp
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -25,6 +27,7 @@ data DidChangeConfigurationRegistrationOptions = DidChangeConfigurationRegistrat
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DidChangeConfigurationRegistrationOptions)
 
 instance Aeson.ToJSON DidChangeConfigurationRegistrationOptions where
   toJSON (DidChangeConfigurationRegistrationOptions arg0) = Aeson.object $ concat $  ["section" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DidChangeNotebookDocumentParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DidChangeNotebookDocumentParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DidChangeNotebookDocumentParams wher
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -47,6 +49,7 @@ data DidChangeNotebookDocumentParams = DidChangeNotebookDocumentParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DidChangeNotebookDocumentParams)
 
 instance Aeson.ToJSON DidChangeNotebookDocumentParams where
   toJSON (DidChangeNotebookDocumentParams arg0 arg1) = Aeson.object $ concat $  [["notebookDocument" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DidChangeTextDocumentParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DidChangeTextDocumentParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DidChangeTextDocumentParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -42,6 +44,7 @@ data DidChangeTextDocumentParams = DidChangeTextDocumentParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DidChangeTextDocumentParams)
 
 instance Aeson.ToJSON DidChangeTextDocumentParams where
   toJSON (DidChangeTextDocumentParams arg0 arg1) = Aeson.object $ concat $  [["textDocument" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DidChangeWatchedFilesClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DidChangeWatchedFilesClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DidChangeWatchedFilesClientCapabilit
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -33,6 +35,7 @@ data DidChangeWatchedFilesClientCapabilities = DidChangeWatchedFilesClientCapabi
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DidChangeWatchedFilesClientCapabilities)
 
 instance Aeson.ToJSON DidChangeWatchedFilesClientCapabilities where
   toJSON (DidChangeWatchedFilesClientCapabilities arg0 arg1) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DidChangeWatchedFilesParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DidChangeWatchedFilesParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DidChangeWatchedFilesParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -25,6 +27,7 @@ data DidChangeWatchedFilesParams = DidChangeWatchedFilesParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DidChangeWatchedFilesParams)
 
 instance Aeson.ToJSON DidChangeWatchedFilesParams where
   toJSON (DidChangeWatchedFilesParams arg0) = Aeson.object $ concat $  [["changes" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DidChangeWatchedFilesRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DidChangeWatchedFilesRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DidChangeWatchedFilesRegistrationOpt
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -25,6 +27,7 @@ data DidChangeWatchedFilesRegistrationOptions = DidChangeWatchedFilesRegistratio
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DidChangeWatchedFilesRegistrationOptions)
 
 instance Aeson.ToJSON DidChangeWatchedFilesRegistrationOptions where
   toJSON (DidChangeWatchedFilesRegistrationOptions arg0) = Aeson.object $ concat $  [["watchers" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DidChangeWorkspaceFoldersParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DidChangeWorkspaceFoldersParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DidChangeWorkspaceFoldersParams wher
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -25,6 +27,7 @@ data DidChangeWorkspaceFoldersParams = DidChangeWorkspaceFoldersParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DidChangeWorkspaceFoldersParams)
 
 instance Aeson.ToJSON DidChangeWorkspaceFoldersParams where
   toJSON (DidChangeWorkspaceFoldersParams arg0) = Aeson.object $ concat $  [["event" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DidCloseNotebookDocumentParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DidCloseNotebookDocumentParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DidCloseNotebookDocumentParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -33,6 +35,7 @@ data DidCloseNotebookDocumentParams = DidCloseNotebookDocumentParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DidCloseNotebookDocumentParams)
 
 instance Aeson.ToJSON DidCloseNotebookDocumentParams where
   toJSON (DidCloseNotebookDocumentParams arg0 arg1) = Aeson.object $ concat $  [["notebookDocument" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DidCloseTextDocumentParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DidCloseTextDocumentParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DidCloseTextDocumentParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -25,6 +27,7 @@ data DidCloseTextDocumentParams = DidCloseTextDocumentParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DidCloseTextDocumentParams)
 
 instance Aeson.ToJSON DidCloseTextDocumentParams where
   toJSON (DidCloseTextDocumentParams arg0) = Aeson.object $ concat $  [["textDocument" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DidOpenNotebookDocumentParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DidOpenNotebookDocumentParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DidOpenNotebookDocumentParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -33,6 +35,7 @@ data DidOpenNotebookDocumentParams = DidOpenNotebookDocumentParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DidOpenNotebookDocumentParams)
 
 instance Aeson.ToJSON DidOpenNotebookDocumentParams where
   toJSON (DidOpenNotebookDocumentParams arg0 arg1) = Aeson.object $ concat $  [["notebookDocument" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DidOpenTextDocumentParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DidOpenTextDocumentParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DidOpenTextDocumentParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -25,6 +27,7 @@ data DidOpenTextDocumentParams = DidOpenTextDocumentParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DidOpenTextDocumentParams)
 
 instance Aeson.ToJSON DidOpenTextDocumentParams where
   toJSON (DidOpenTextDocumentParams arg0) = Aeson.object $ concat $  [["textDocument" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DidSaveNotebookDocumentParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DidSaveNotebookDocumentParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DidSaveNotebookDocumentParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -27,6 +29,7 @@ data DidSaveNotebookDocumentParams = DidSaveNotebookDocumentParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DidSaveNotebookDocumentParams)
 
 instance Aeson.ToJSON DidSaveNotebookDocumentParams where
   toJSON (DidSaveNotebookDocumentParams arg0) = Aeson.object $ concat $  [["notebookDocument" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DidSaveTextDocumentParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DidSaveTextDocumentParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DidSaveTextDocumentParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -31,6 +33,7 @@ data DidSaveTextDocumentParams = DidSaveTextDocumentParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DidSaveTextDocumentParams)
 
 instance Aeson.ToJSON DidSaveTextDocumentParams where
   toJSON (DidSaveTextDocumentParams arg0 arg1) = Aeson.object $ concat $  [["textDocument" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentColorClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentColorClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentColorClientCapabilities wher
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -26,6 +28,7 @@ data DocumentColorClientCapabilities = DocumentColorClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentColorClientCapabilities)
 
 instance Aeson.ToJSON DocumentColorClientCapabilities where
   toJSON (DocumentColorClientCapabilities arg0) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentColorOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentColorOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentColorOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -24,6 +26,7 @@ data DocumentColorOptions = DocumentColorOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentColorOptions)
 
 instance Aeson.ToJSON DocumentColorOptions where
   toJSON (DocumentColorOptions arg0) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentColorParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentColorParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentColorParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -35,6 +37,7 @@ data DocumentColorParams = DocumentColorParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentColorParams)
 
 instance Aeson.ToJSON DocumentColorParams where
   toJSON (DocumentColorParams arg0 arg1 arg2) = Aeson.object $ concat $  ["workDoneToken" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentColorRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentColorRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentColorRegistrationOptions whe
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -36,6 +38,7 @@ data DocumentColorRegistrationOptions = DocumentColorRegistrationOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentColorRegistrationOptions)
 
 instance Aeson.ToJSON DocumentColorRegistrationOptions where
   toJSON (DocumentColorRegistrationOptions arg0 arg1 arg2) = Aeson.object $ concat $  [["documentSelector" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentDiagnosticParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentDiagnosticParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentDiagnosticParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -46,6 +48,7 @@ data DocumentDiagnosticParams = DocumentDiagnosticParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentDiagnosticParams)
 
 instance Aeson.ToJSON DocumentDiagnosticParams where
   toJSON (DocumentDiagnosticParams arg0 arg1 arg2 arg3 arg4) = Aeson.object $ concat $  ["workDoneToken" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentDiagnosticReport.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentDiagnosticReport.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentDiagnosticReport where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -28,3 +30,4 @@ newtype DocumentDiagnosticReport = DocumentDiagnosticReport (Language.LSP.Protoc
   deriving newtype (Aeson.ToJSON, Aeson.FromJSON)
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentDiagnosticReport)

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentDiagnosticReportKind.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentDiagnosticReportKind.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentDiagnosticReportKind where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -36,6 +38,7 @@ data DocumentDiagnosticReportKind =
   deriving anyclass (NFData, Hashable)
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum DocumentDiagnosticReportKind Data.Text.Text)
+  deriving Pretty via (ViaJSON DocumentDiagnosticReportKind)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum DocumentDiagnosticReportKind where
   knownValues = Data.Set.fromList [DocumentDiagnosticReportKind_Full

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentDiagnosticReportPartialResult.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentDiagnosticReportPartialResult.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentDiagnosticReportPartialResul
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Map
 import qualified Data.Row.Aeson as Aeson
@@ -30,6 +32,7 @@ data DocumentDiagnosticReportPartialResult = DocumentDiagnosticReportPartialResu
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentDiagnosticReportPartialResult)
 
 instance Aeson.ToJSON DocumentDiagnosticReportPartialResult where
   toJSON (DocumentDiagnosticReportPartialResult arg0) = Aeson.object $ concat $  [["relatedDocuments" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentFilter.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentFilter.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentFilter where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -25,3 +27,4 @@ newtype DocumentFilter = DocumentFilter (Language.LSP.Protocol.Internal.Types.Te
   deriving newtype (Aeson.ToJSON, Aeson.FromJSON)
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentFilter)

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentFormattingClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentFormattingClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentFormattingClientCapabilities
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -24,6 +26,7 @@ data DocumentFormattingClientCapabilities = DocumentFormattingClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentFormattingClientCapabilities)
 
 instance Aeson.ToJSON DocumentFormattingClientCapabilities where
   toJSON (DocumentFormattingClientCapabilities arg0) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentFormattingOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentFormattingOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentFormattingOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -24,6 +26,7 @@ data DocumentFormattingOptions = DocumentFormattingOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentFormattingOptions)
 
 instance Aeson.ToJSON DocumentFormattingOptions where
   toJSON (DocumentFormattingOptions arg0) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentFormattingParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentFormattingParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentFormattingParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -35,6 +37,7 @@ data DocumentFormattingParams = DocumentFormattingParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentFormattingParams)
 
 instance Aeson.ToJSON DocumentFormattingParams where
   toJSON (DocumentFormattingParams arg0 arg1 arg2) = Aeson.object $ concat $  ["workDoneToken" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentFormattingRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentFormattingRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentFormattingRegistrationOption
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -30,6 +32,7 @@ data DocumentFormattingRegistrationOptions = DocumentFormattingRegistrationOptio
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentFormattingRegistrationOptions)
 
 instance Aeson.ToJSON DocumentFormattingRegistrationOptions where
   toJSON (DocumentFormattingRegistrationOptions arg0 arg1) = Aeson.object $ concat $  [["documentSelector" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentHighlight.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentHighlight.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentHighlight where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -32,6 +34,7 @@ data DocumentHighlight = DocumentHighlight
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentHighlight)
 
 instance Aeson.ToJSON DocumentHighlight where
   toJSON (DocumentHighlight arg0 arg1) = Aeson.object $ concat $  [["range" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentHighlightClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentHighlightClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentHighlightClientCapabilities 
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -24,6 +26,7 @@ data DocumentHighlightClientCapabilities = DocumentHighlightClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentHighlightClientCapabilities)
 
 instance Aeson.ToJSON DocumentHighlightClientCapabilities where
   toJSON (DocumentHighlightClientCapabilities arg0) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentHighlightKind.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentHighlightKind.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentHighlightKind where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -36,6 +38,7 @@ data DocumentHighlightKind =
   deriving anyclass (NFData, Hashable)
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum DocumentHighlightKind Language.LSP.Protocol.Types.Common.UInt)
+  deriving Pretty via (ViaJSON DocumentHighlightKind)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum DocumentHighlightKind where
   knownValues = Data.Set.fromList [DocumentHighlightKind_Text

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentHighlightOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentHighlightOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentHighlightOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -24,6 +26,7 @@ data DocumentHighlightOptions = DocumentHighlightOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentHighlightOptions)
 
 instance Aeson.ToJSON DocumentHighlightOptions where
   toJSON (DocumentHighlightOptions arg0) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentHighlightParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentHighlightParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentHighlightParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -40,6 +42,7 @@ data DocumentHighlightParams = DocumentHighlightParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentHighlightParams)
 
 instance Aeson.ToJSON DocumentHighlightParams where
   toJSON (DocumentHighlightParams arg0 arg1 arg2 arg3) = Aeson.object $ concat $  [["textDocument" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentHighlightRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentHighlightRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentHighlightRegistrationOptions
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -30,6 +32,7 @@ data DocumentHighlightRegistrationOptions = DocumentHighlightRegistrationOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentHighlightRegistrationOptions)
 
 instance Aeson.ToJSON DocumentHighlightRegistrationOptions where
   toJSON (DocumentHighlightRegistrationOptions arg0 arg1) = Aeson.object $ concat $  [["documentSelector" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentLink.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentLink.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentLink where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
@@ -47,6 +49,7 @@ data DocumentLink = DocumentLink
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentLink)
 
 instance Aeson.ToJSON DocumentLink where
   toJSON (DocumentLink arg0 arg1 arg2 arg3) = Aeson.object $ concat $  [["range" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentLinkClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentLinkClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentLinkClientCapabilities where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -30,6 +32,7 @@ data DocumentLinkClientCapabilities = DocumentLinkClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentLinkClientCapabilities)
 
 instance Aeson.ToJSON DocumentLinkClientCapabilities where
   toJSON (DocumentLinkClientCapabilities arg0 arg1) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentLinkOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentLinkOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentLinkOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -28,6 +30,7 @@ data DocumentLinkOptions = DocumentLinkOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentLinkOptions)
 
 instance Aeson.ToJSON DocumentLinkOptions where
   toJSON (DocumentLinkOptions arg0 arg1) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentLinkParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentLinkParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentLinkParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -35,6 +37,7 @@ data DocumentLinkParams = DocumentLinkParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentLinkParams)
 
 instance Aeson.ToJSON DocumentLinkParams where
   toJSON (DocumentLinkParams arg0 arg1 arg2) = Aeson.object $ concat $  ["workDoneToken" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentLinkRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentLinkRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentLinkRegistrationOptions wher
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -34,6 +36,7 @@ data DocumentLinkRegistrationOptions = DocumentLinkRegistrationOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentLinkRegistrationOptions)
 
 instance Aeson.ToJSON DocumentLinkRegistrationOptions where
   toJSON (DocumentLinkRegistrationOptions arg0 arg1 arg2) = Aeson.object $ concat $  [["documentSelector" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentOnTypeFormattingClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentOnTypeFormattingClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentOnTypeFormattingClientCapabi
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -24,6 +26,7 @@ data DocumentOnTypeFormattingClientCapabilities = DocumentOnTypeFormattingClient
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentOnTypeFormattingClientCapabilities)
 
 instance Aeson.ToJSON DocumentOnTypeFormattingClientCapabilities where
   toJSON (DocumentOnTypeFormattingClientCapabilities arg0) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentOnTypeFormattingOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentOnTypeFormattingOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentOnTypeFormattingOptions wher
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -29,6 +31,7 @@ data DocumentOnTypeFormattingOptions = DocumentOnTypeFormattingOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentOnTypeFormattingOptions)
 
 instance Aeson.ToJSON DocumentOnTypeFormattingOptions where
   toJSON (DocumentOnTypeFormattingOptions arg0 arg1) = Aeson.object $ concat $  [["firstTriggerCharacter" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentOnTypeFormattingParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentOnTypeFormattingParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentOnTypeFormattingParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -45,6 +47,7 @@ data DocumentOnTypeFormattingParams = DocumentOnTypeFormattingParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentOnTypeFormattingParams)
 
 instance Aeson.ToJSON DocumentOnTypeFormattingParams where
   toJSON (DocumentOnTypeFormattingParams arg0 arg1 arg2 arg3) = Aeson.object $ concat $  [["textDocument" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentOnTypeFormattingRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentOnTypeFormattingRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentOnTypeFormattingRegistration
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -35,6 +37,7 @@ data DocumentOnTypeFormattingRegistrationOptions = DocumentOnTypeFormattingRegis
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentOnTypeFormattingRegistrationOptions)
 
 instance Aeson.ToJSON DocumentOnTypeFormattingRegistrationOptions where
   toJSON (DocumentOnTypeFormattingRegistrationOptions arg0 arg1 arg2) = Aeson.object $ concat $  [["documentSelector" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentRangeFormattingClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentRangeFormattingClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentRangeFormattingClientCapabil
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -24,6 +26,7 @@ data DocumentRangeFormattingClientCapabilities = DocumentRangeFormattingClientCa
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentRangeFormattingClientCapabilities)
 
 instance Aeson.ToJSON DocumentRangeFormattingClientCapabilities where
   toJSON (DocumentRangeFormattingClientCapabilities arg0) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentRangeFormattingOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentRangeFormattingOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentRangeFormattingOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -24,6 +26,7 @@ data DocumentRangeFormattingOptions = DocumentRangeFormattingOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentRangeFormattingOptions)
 
 instance Aeson.ToJSON DocumentRangeFormattingOptions where
   toJSON (DocumentRangeFormattingOptions arg0) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentRangeFormattingParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentRangeFormattingParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentRangeFormattingParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -40,6 +42,7 @@ data DocumentRangeFormattingParams = DocumentRangeFormattingParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentRangeFormattingParams)
 
 instance Aeson.ToJSON DocumentRangeFormattingParams where
   toJSON (DocumentRangeFormattingParams arg0 arg1 arg2 arg3) = Aeson.object $ concat $  ["workDoneToken" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentRangeFormattingRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentRangeFormattingRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentRangeFormattingRegistrationO
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -30,6 +32,7 @@ data DocumentRangeFormattingRegistrationOptions = DocumentRangeFormattingRegistr
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentRangeFormattingRegistrationOptions)
 
 instance Aeson.ToJSON DocumentRangeFormattingRegistrationOptions where
   toJSON (DocumentRangeFormattingRegistrationOptions arg0 arg1) = Aeson.object $ concat $  [["documentSelector" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentSelector.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentSelector.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentSelector where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -24,3 +26,4 @@ newtype DocumentSelector = DocumentSelector [Language.LSP.Protocol.Internal.Type
   deriving newtype (Aeson.ToJSON, Aeson.FromJSON)
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentSelector)

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentSymbol.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentSymbol.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentSymbol where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -67,6 +69,7 @@ data DocumentSymbol = DocumentSymbol
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentSymbol)
 
 instance Aeson.ToJSON DocumentSymbol where
   toJSON (DocumentSymbol arg0 arg1 arg2 arg3 arg4 arg5 arg6 arg7) = Aeson.object $ concat $  [["name" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentSymbolClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentSymbolClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentSymbolClientCapabilities whe
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row as Row
 import qualified Data.Row.Aeson as Aeson
@@ -51,6 +53,7 @@ data DocumentSymbolClientCapabilities = DocumentSymbolClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentSymbolClientCapabilities)
 
 instance Aeson.ToJSON DocumentSymbolClientCapabilities where
   toJSON (DocumentSymbolClientCapabilities arg0 arg1 arg2 arg3 arg4) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentSymbolOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentSymbolOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentSymbolOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -32,6 +34,7 @@ data DocumentSymbolOptions = DocumentSymbolOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentSymbolOptions)
 
 instance Aeson.ToJSON DocumentSymbolOptions where
   toJSON (DocumentSymbolOptions arg0 arg1) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentSymbolParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentSymbolParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentSymbolParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -35,6 +37,7 @@ data DocumentSymbolParams = DocumentSymbolParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentSymbolParams)
 
 instance Aeson.ToJSON DocumentSymbolParams where
   toJSON (DocumentSymbolParams arg0 arg1 arg2) = Aeson.object $ concat $  ["workDoneToken" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentSymbolRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/DocumentSymbolRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.DocumentSymbolRegistrationOptions wh
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -38,6 +40,7 @@ data DocumentSymbolRegistrationOptions = DocumentSymbolRegistrationOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON DocumentSymbolRegistrationOptions)
 
 instance Aeson.ToJSON DocumentSymbolRegistrationOptions where
   toJSON (DocumentSymbolRegistrationOptions arg0 arg1 arg2) = Aeson.object $ concat $  [["documentSelector" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ErrorCodes.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ErrorCodes.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ErrorCodes where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -54,6 +56,7 @@ data ErrorCodes =
   deriving anyclass (NFData, Hashable)
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum ErrorCodes Language.LSP.Protocol.Types.Common.Int32)
+  deriving Pretty via (ViaJSON ErrorCodes)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum ErrorCodes where
   knownValues = Data.Set.fromList [ErrorCodes_ParseError

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ExecuteCommandClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ExecuteCommandClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ExecuteCommandClientCapabilities whe
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -24,6 +26,7 @@ data ExecuteCommandClientCapabilities = ExecuteCommandClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ExecuteCommandClientCapabilities)
 
 instance Aeson.ToJSON ExecuteCommandClientCapabilities where
   toJSON (ExecuteCommandClientCapabilities arg0) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ExecuteCommandOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ExecuteCommandOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ExecuteCommandOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -29,6 +31,7 @@ data ExecuteCommandOptions = ExecuteCommandOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ExecuteCommandOptions)
 
 instance Aeson.ToJSON ExecuteCommandOptions where
   toJSON (ExecuteCommandOptions arg0 arg1) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ExecuteCommandParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ExecuteCommandParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ExecuteCommandParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
@@ -35,6 +37,7 @@ data ExecuteCommandParams = ExecuteCommandParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ExecuteCommandParams)
 
 instance Aeson.ToJSON ExecuteCommandParams where
   toJSON (ExecuteCommandParams arg0 arg1 arg2) = Aeson.object $ concat $  ["workDoneToken" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ExecuteCommandRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ExecuteCommandRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ExecuteCommandRegistrationOptions wh
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -29,6 +31,7 @@ data ExecuteCommandRegistrationOptions = ExecuteCommandRegistrationOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ExecuteCommandRegistrationOptions)
 
 instance Aeson.ToJSON ExecuteCommandRegistrationOptions where
   toJSON (ExecuteCommandRegistrationOptions arg0 arg1) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ExecutionSummary.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ExecutionSummary.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ExecutionSummary where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -31,6 +33,7 @@ data ExecutionSummary = ExecutionSummary
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ExecutionSummary)
 
 instance Aeson.ToJSON ExecutionSummary where
   toJSON (ExecutionSummary arg0 arg1) = Aeson.object $ concat $  [["executionOrder" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FailureHandlingKind.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FailureHandlingKind.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.FailureHandlingKind where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -45,6 +47,7 @@ data FailureHandlingKind =
   deriving anyclass (NFData, Hashable)
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum FailureHandlingKind Data.Text.Text)
+  deriving Pretty via (ViaJSON FailureHandlingKind)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum FailureHandlingKind where
   knownValues = Data.Set.fromList [FailureHandlingKind_Abort

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FileChangeType.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FileChangeType.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.FileChangeType where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -36,6 +38,7 @@ data FileChangeType =
   deriving anyclass (NFData, Hashable)
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum FileChangeType Language.LSP.Protocol.Types.Common.UInt)
+  deriving Pretty via (ViaJSON FileChangeType)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum FileChangeType where
   knownValues = Data.Set.fromList [FileChangeType_Created

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FileCreate.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FileCreate.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.FileCreate where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -27,6 +29,7 @@ data FileCreate = FileCreate
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON FileCreate)
 
 instance Aeson.ToJSON FileCreate where
   toJSON (FileCreate arg0) = Aeson.object $ concat $  [["uri" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FileDelete.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FileDelete.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.FileDelete where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -27,6 +29,7 @@ data FileDelete = FileDelete
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON FileDelete)
 
 instance Aeson.ToJSON FileDelete where
   toJSON (FileDelete arg0) = Aeson.object $ concat $  [["uri" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FileEvent.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FileEvent.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.FileEvent where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -30,6 +32,7 @@ data FileEvent = FileEvent
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON FileEvent)
 
 instance Aeson.ToJSON FileEvent where
   toJSON (FileEvent arg0 arg1) = Aeson.object $ concat $  [["uri" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FileOperationClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FileOperationClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.FileOperationClientCapabilities wher
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -53,6 +55,7 @@ data FileOperationClientCapabilities = FileOperationClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON FileOperationClientCapabilities)
 
 instance Aeson.ToJSON FileOperationClientCapabilities where
   toJSON (FileOperationClientCapabilities arg0 arg1 arg2 arg3 arg4 arg5 arg6) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FileOperationFilter.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FileOperationFilter.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.FileOperationFilter where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -33,6 +35,7 @@ data FileOperationFilter = FileOperationFilter
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON FileOperationFilter)
 
 instance Aeson.ToJSON FileOperationFilter where
   toJSON (FileOperationFilter arg0 arg1) = Aeson.object $ concat $  ["scheme" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FileOperationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FileOperationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.FileOperationOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -47,6 +49,7 @@ data FileOperationOptions = FileOperationOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON FileOperationOptions)
 
 instance Aeson.ToJSON FileOperationOptions where
   toJSON (FileOperationOptions arg0 arg1 arg2 arg3 arg4 arg5) = Aeson.object $ concat $  ["didCreate" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FileOperationPattern.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FileOperationPattern.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.FileOperationPattern where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -46,6 +48,7 @@ data FileOperationPattern = FileOperationPattern
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON FileOperationPattern)
 
 instance Aeson.ToJSON FileOperationPattern where
   toJSON (FileOperationPattern arg0 arg1 arg2) = Aeson.object $ concat $  [["glob" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FileOperationPatternKind.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FileOperationPatternKind.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.FileOperationPatternKind where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -35,6 +37,7 @@ data FileOperationPatternKind =
   deriving anyclass (NFData, Hashable)
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum FileOperationPatternKind Data.Text.Text)
+  deriving Pretty via (ViaJSON FileOperationPatternKind)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum FileOperationPatternKind where
   knownValues = Data.Set.fromList [FileOperationPatternKind_File

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FileOperationPatternOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FileOperationPatternOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.FileOperationPatternOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -26,6 +28,7 @@ data FileOperationPatternOptions = FileOperationPatternOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON FileOperationPatternOptions)
 
 instance Aeson.ToJSON FileOperationPatternOptions where
   toJSON (FileOperationPatternOptions arg0) = Aeson.object $ concat $  ["ignoreCase" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FileOperationRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FileOperationRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.FileOperationRegistrationOptions whe
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -27,6 +29,7 @@ data FileOperationRegistrationOptions = FileOperationRegistrationOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON FileOperationRegistrationOptions)
 
 instance Aeson.ToJSON FileOperationRegistrationOptions where
   toJSON (FileOperationRegistrationOptions arg0) = Aeson.object $ concat $  [["filters" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FileRename.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FileRename.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.FileRename where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -31,6 +33,7 @@ data FileRename = FileRename
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON FileRename)
 
 instance Aeson.ToJSON FileRename where
   toJSON (FileRename arg0 arg1) = Aeson.object $ concat $  [["oldUri" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FileSystemWatcher.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FileSystemWatcher.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.FileSystemWatcher where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -34,6 +36,7 @@ data FileSystemWatcher = FileSystemWatcher
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON FileSystemWatcher)
 
 instance Aeson.ToJSON FileSystemWatcher where
   toJSON (FileSystemWatcher arg0 arg1) = Aeson.object $ concat $  [["globPattern" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FoldingRange.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FoldingRange.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.FoldingRange where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -55,6 +57,7 @@ data FoldingRange = FoldingRange
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON FoldingRange)
 
 instance Aeson.ToJSON FoldingRange where
   toJSON (FoldingRange arg0 arg1 arg2 arg3 arg4 arg5) = Aeson.object $ concat $  [["startLine" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FoldingRangeClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FoldingRangeClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.FoldingRangeClientCapabilities where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row as Row
 import qualified Data.Row.Aeson as Aeson
@@ -53,6 +55,7 @@ data FoldingRangeClientCapabilities = FoldingRangeClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON FoldingRangeClientCapabilities)
 
 instance Aeson.ToJSON FoldingRangeClientCapabilities where
   toJSON (FoldingRangeClientCapabilities arg0 arg1 arg2 arg3 arg4) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FoldingRangeKind.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FoldingRangeKind.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.FoldingRangeKind where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -38,6 +40,7 @@ data FoldingRangeKind =
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON
   , Data.String.IsString ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum FoldingRangeKind Data.Text.Text)
+  deriving Pretty via (ViaJSON FoldingRangeKind)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum FoldingRangeKind where
   knownValues = Data.Set.fromList [FoldingRangeKind_Comment

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FoldingRangeOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FoldingRangeOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.FoldingRangeOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -24,6 +26,7 @@ data FoldingRangeOptions = FoldingRangeOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON FoldingRangeOptions)
 
 instance Aeson.ToJSON FoldingRangeOptions where
   toJSON (FoldingRangeOptions arg0) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FoldingRangeParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FoldingRangeParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.FoldingRangeParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -35,6 +37,7 @@ data FoldingRangeParams = FoldingRangeParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON FoldingRangeParams)
 
 instance Aeson.ToJSON FoldingRangeParams where
   toJSON (FoldingRangeParams arg0 arg1 arg2) = Aeson.object $ concat $  ["workDoneToken" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FoldingRangeRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FoldingRangeRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.FoldingRangeRegistrationOptions wher
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -36,6 +38,7 @@ data FoldingRangeRegistrationOptions = FoldingRangeRegistrationOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON FoldingRangeRegistrationOptions)
 
 instance Aeson.ToJSON FoldingRangeRegistrationOptions where
   toJSON (FoldingRangeRegistrationOptions arg0 arg1 arg2) = Aeson.object $ concat $  [["documentSelector" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FormattingOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FormattingOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.FormattingOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -46,6 +48,7 @@ data FormattingOptions = FormattingOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON FormattingOptions)
 
 instance Aeson.ToJSON FormattingOptions where
   toJSON (FormattingOptions arg0 arg1 arg2 arg3 arg4) = Aeson.object $ concat $  [["tabSize" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FullDocumentDiagnosticReport.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/FullDocumentDiagnosticReport.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.FullDocumentDiagnosticReport where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -39,6 +41,7 @@ data FullDocumentDiagnosticReport = FullDocumentDiagnosticReport
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON FullDocumentDiagnosticReport)
 
 instance Aeson.ToJSON FullDocumentDiagnosticReport where
   toJSON (FullDocumentDiagnosticReport arg0 arg1 arg2) = Aeson.object $ concat $  [["kind" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/GeneralClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/GeneralClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.GeneralClientCapabilities where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row as Row
 import qualified Data.Row.Aeson as Aeson
@@ -69,6 +71,7 @@ data GeneralClientCapabilities = GeneralClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON GeneralClientCapabilities)
 
 instance Aeson.ToJSON GeneralClientCapabilities where
   toJSON (GeneralClientCapabilities arg0 arg1 arg2 arg3) = Aeson.object $ concat $  ["staleRequestSupport" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/GlobPattern.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/GlobPattern.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.GlobPattern where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -24,3 +26,4 @@ newtype GlobPattern = GlobPattern (Language.LSP.Protocol.Internal.Types.Pattern.
   deriving newtype (Aeson.ToJSON, Aeson.FromJSON)
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON GlobPattern)

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/Hover.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/Hover.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.Hover where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -32,6 +34,7 @@ data Hover = Hover
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON Hover)
 
 instance Aeson.ToJSON Hover where
   toJSON (Hover arg0 arg1) = Aeson.object $ concat $  [["contents" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/HoverClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/HoverClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.HoverClientCapabilities where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -30,6 +32,7 @@ data HoverClientCapabilities = HoverClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON HoverClientCapabilities)
 
 instance Aeson.ToJSON HoverClientCapabilities where
   toJSON (HoverClientCapabilities arg0 arg1) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/HoverOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/HoverOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.HoverOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -24,6 +26,7 @@ data HoverOptions = HoverOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON HoverOptions)
 
 instance Aeson.ToJSON HoverOptions where
   toJSON (HoverOptions arg0) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/HoverParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/HoverParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.HoverParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -35,6 +37,7 @@ data HoverParams = HoverParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON HoverParams)
 
 instance Aeson.ToJSON HoverParams where
   toJSON (HoverParams arg0 arg1 arg2) = Aeson.object $ concat $  [["textDocument" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/HoverRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/HoverRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.HoverRegistrationOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -30,6 +32,7 @@ data HoverRegistrationOptions = HoverRegistrationOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON HoverRegistrationOptions)
 
 instance Aeson.ToJSON HoverRegistrationOptions where
   toJSON (HoverRegistrationOptions arg0 arg1) = Aeson.object $ concat $  [["documentSelector" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ImplementationClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ImplementationClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ImplementationClientCapabilities whe
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -32,6 +34,7 @@ data ImplementationClientCapabilities = ImplementationClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ImplementationClientCapabilities)
 
 instance Aeson.ToJSON ImplementationClientCapabilities where
   toJSON (ImplementationClientCapabilities arg0 arg1) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ImplementationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ImplementationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ImplementationOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -24,6 +26,7 @@ data ImplementationOptions = ImplementationOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ImplementationOptions)
 
 instance Aeson.ToJSON ImplementationOptions where
   toJSON (ImplementationOptions arg0) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ImplementationParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ImplementationParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ImplementationParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -40,6 +42,7 @@ data ImplementationParams = ImplementationParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ImplementationParams)
 
 instance Aeson.ToJSON ImplementationParams where
   toJSON (ImplementationParams arg0 arg1 arg2 arg3) = Aeson.object $ concat $  [["textDocument" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ImplementationRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ImplementationRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ImplementationRegistrationOptions wh
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -36,6 +38,7 @@ data ImplementationRegistrationOptions = ImplementationRegistrationOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ImplementationRegistrationOptions)
 
 instance Aeson.ToJSON ImplementationRegistrationOptions where
   toJSON (ImplementationRegistrationOptions arg0 arg1 arg2) = Aeson.object $ concat $  [["documentSelector" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InitializeError.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InitializeError.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.InitializeError where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -28,6 +30,7 @@ data InitializeError = InitializeError
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON InitializeError)
 
 instance Aeson.ToJSON InitializeError where
   toJSON (InitializeError arg0) = Aeson.object $ concat $  [["retry" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InitializeParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InitializeParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.InitializeParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson
 import qualified Data.Aeson as Aeson
 import qualified Data.Row as Row
@@ -94,6 +96,7 @@ data InitializeParams = InitializeParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON InitializeParams)
 
 instance Aeson.ToJSON InitializeParams where
   toJSON (InitializeParams arg0 arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9) = Aeson.object $ concat $  ["workDoneToken" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InitializeResult.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InitializeResult.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.InitializeResult where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row as Row
 import qualified Data.Row.Aeson as Aeson
@@ -33,6 +35,7 @@ data InitializeResult = InitializeResult
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON InitializeResult)
 
 instance Aeson.ToJSON InitializeResult where
   toJSON (InitializeResult arg0 arg1) = Aeson.object $ concat $  [["capabilities" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InitializedParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InitializedParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.InitializedParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -21,6 +23,7 @@ data InitializedParams = InitializedParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON InitializedParams)
 
 instance Aeson.ToJSON InitializedParams where
   toJSON (InitializedParams ) = Aeson.object $ concat $  []

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlayHint.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlayHint.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.InlayHint where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
@@ -78,6 +80,7 @@ data InlayHint = InlayHint
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON InlayHint)
 
 instance Aeson.ToJSON InlayHint where
   toJSON (InlayHint arg0 arg1 arg2 arg3 arg4 arg5 arg6 arg7) = Aeson.object $ concat $  [["position" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlayHintClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlayHintClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.InlayHintClientCapabilities where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row as Row
 import qualified Data.Row.Aeson as Aeson
@@ -33,6 +35,7 @@ data InlayHintClientCapabilities = InlayHintClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON InlayHintClientCapabilities)
 
 instance Aeson.ToJSON InlayHintClientCapabilities where
   toJSON (InlayHintClientCapabilities arg0 arg1) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlayHintKind.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlayHintKind.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.InlayHintKind where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -34,6 +36,7 @@ data InlayHintKind =
   deriving anyclass (NFData, Hashable)
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum InlayHintKind Language.LSP.Protocol.Types.Common.UInt)
+  deriving Pretty via (ViaJSON InlayHintKind)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum InlayHintKind where
   knownValues = Data.Set.fromList [InlayHintKind_Type,InlayHintKind_Parameter]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlayHintLabelPart.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlayHintLabelPart.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.InlayHintLabelPart where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -58,6 +60,7 @@ data InlayHintLabelPart = InlayHintLabelPart
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON InlayHintLabelPart)
 
 instance Aeson.ToJSON InlayHintLabelPart where
   toJSON (InlayHintLabelPart arg0 arg1 arg2 arg3) = Aeson.object $ concat $  [["value" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlayHintOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlayHintOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.InlayHintOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -31,6 +33,7 @@ data InlayHintOptions = InlayHintOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON InlayHintOptions)
 
 instance Aeson.ToJSON InlayHintOptions where
   toJSON (InlayHintOptions arg0 arg1) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlayHintParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlayHintParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.InlayHintParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -37,6 +39,7 @@ data InlayHintParams = InlayHintParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON InlayHintParams)
 
 instance Aeson.ToJSON InlayHintParams where
   toJSON (InlayHintParams arg0 arg1 arg2) = Aeson.object $ concat $  ["workDoneToken" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlayHintRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlayHintRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.InlayHintRegistrationOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -43,6 +45,7 @@ data InlayHintRegistrationOptions = InlayHintRegistrationOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON InlayHintRegistrationOptions)
 
 instance Aeson.ToJSON InlayHintRegistrationOptions where
   toJSON (InlayHintRegistrationOptions arg0 arg1 arg2 arg3) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlayHintWorkspaceClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlayHintWorkspaceClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.InlayHintWorkspaceClientCapabilities
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -32,6 +34,7 @@ data InlayHintWorkspaceClientCapabilities = InlayHintWorkspaceClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON InlayHintWorkspaceClientCapabilities)
 
 instance Aeson.ToJSON InlayHintWorkspaceClientCapabilities where
   toJSON (InlayHintWorkspaceClientCapabilities arg0) = Aeson.object $ concat $  ["refreshSupport" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlineValue.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlineValue.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.InlineValue where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -29,3 +31,4 @@ newtype InlineValue = InlineValue (Language.LSP.Protocol.Internal.Types.InlineVa
   deriving newtype (Aeson.ToJSON, Aeson.FromJSON)
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON InlineValue)

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlineValueClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlineValueClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.InlineValueClientCapabilities where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -26,6 +28,7 @@ data InlineValueClientCapabilities = InlineValueClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON InlineValueClientCapabilities)
 
 instance Aeson.ToJSON InlineValueClientCapabilities where
   toJSON (InlineValueClientCapabilities arg0) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlineValueContext.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlineValueContext.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.InlineValueContext where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -30,6 +32,7 @@ data InlineValueContext = InlineValueContext
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON InlineValueContext)
 
 instance Aeson.ToJSON InlineValueContext where
   toJSON (InlineValueContext arg0 arg1) = Aeson.object $ concat $  [["frameId" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlineValueEvaluatableExpression.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlineValueEvaluatableExpression.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.InlineValueEvaluatableExpression whe
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -35,6 +37,7 @@ data InlineValueEvaluatableExpression = InlineValueEvaluatableExpression
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON InlineValueEvaluatableExpression)
 
 instance Aeson.ToJSON InlineValueEvaluatableExpression where
   toJSON (InlineValueEvaluatableExpression arg0 arg1) = Aeson.object $ concat $  [["range" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlineValueOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlineValueOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.InlineValueOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -26,6 +28,7 @@ data InlineValueOptions = InlineValueOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON InlineValueOptions)
 
 instance Aeson.ToJSON InlineValueOptions where
   toJSON (InlineValueOptions arg0) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlineValueParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlineValueParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.InlineValueParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -43,6 +45,7 @@ data InlineValueParams = InlineValueParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON InlineValueParams)
 
 instance Aeson.ToJSON InlineValueParams where
   toJSON (InlineValueParams arg0 arg1 arg2 arg3) = Aeson.object $ concat $  ["workDoneToken" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlineValueRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlineValueRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.InlineValueRegistrationOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -38,6 +40,7 @@ data InlineValueRegistrationOptions = InlineValueRegistrationOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON InlineValueRegistrationOptions)
 
 instance Aeson.ToJSON InlineValueRegistrationOptions where
   toJSON (InlineValueRegistrationOptions arg0 arg1 arg2) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlineValueText.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlineValueText.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.InlineValueText where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -32,6 +34,7 @@ data InlineValueText = InlineValueText
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON InlineValueText)
 
 instance Aeson.ToJSON InlineValueText where
   toJSON (InlineValueText arg0 arg1) = Aeson.object $ concat $  [["range" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlineValueVariableLookup.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlineValueVariableLookup.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.InlineValueVariableLookup where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -39,6 +41,7 @@ data InlineValueVariableLookup = InlineValueVariableLookup
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON InlineValueVariableLookup)
 
 instance Aeson.ToJSON InlineValueVariableLookup where
   toJSON (InlineValueVariableLookup arg0 arg1 arg2) = Aeson.object $ concat $  [["range" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlineValueWorkspaceClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InlineValueWorkspaceClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.InlineValueWorkspaceClientCapabiliti
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -32,6 +34,7 @@ data InlineValueWorkspaceClientCapabilities = InlineValueWorkspaceClientCapabili
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON InlineValueWorkspaceClientCapabilities)
 
 instance Aeson.ToJSON InlineValueWorkspaceClientCapabilities where
   toJSON (InlineValueWorkspaceClientCapabilities arg0) = Aeson.object $ concat $  ["refreshSupport" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InsertReplaceEdit.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InsertReplaceEdit.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.InsertReplaceEdit where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -36,6 +38,7 @@ data InsertReplaceEdit = InsertReplaceEdit
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON InsertReplaceEdit)
 
 instance Aeson.ToJSON InsertReplaceEdit where
   toJSON (InsertReplaceEdit arg0 arg1 arg2) = Aeson.object $ concat $  [["newText" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InsertTextFormat.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InsertTextFormat.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.InsertTextFormat where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -40,6 +42,7 @@ data InsertTextFormat =
   deriving anyclass (NFData, Hashable)
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum InsertTextFormat Language.LSP.Protocol.Types.Common.UInt)
+  deriving Pretty via (ViaJSON InsertTextFormat)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum InsertTextFormat where
   knownValues = Data.Set.fromList [InsertTextFormat_PlainText

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InsertTextMode.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/InsertTextMode.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.InsertTextMode where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -45,6 +47,7 @@ data InsertTextMode =
   deriving anyclass (NFData, Hashable)
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum InsertTextMode Language.LSP.Protocol.Types.Common.UInt)
+  deriving Pretty via (ViaJSON InsertTextMode)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum InsertTextMode where
   knownValues = Data.Set.fromList [InsertTextMode_AsIs

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/LSPErrorCodes.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/LSPErrorCodes.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.LSPErrorCodes where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -58,6 +60,7 @@ data LSPErrorCodes =
   deriving anyclass (NFData, Hashable)
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum LSPErrorCodes Language.LSP.Protocol.Types.Common.Int32)
+  deriving Pretty via (ViaJSON LSPErrorCodes)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum LSPErrorCodes where
   knownValues = Data.Set.fromList [LSPErrorCodes_RequestFailed

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/LinkedEditingRangeClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/LinkedEditingRangeClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.LinkedEditingRangeClientCapabilities
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -28,6 +30,7 @@ data LinkedEditingRangeClientCapabilities = LinkedEditingRangeClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON LinkedEditingRangeClientCapabilities)
 
 instance Aeson.ToJSON LinkedEditingRangeClientCapabilities where
   toJSON (LinkedEditingRangeClientCapabilities arg0) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/LinkedEditingRangeOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/LinkedEditingRangeOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.LinkedEditingRangeOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -24,6 +26,7 @@ data LinkedEditingRangeOptions = LinkedEditingRangeOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON LinkedEditingRangeOptions)
 
 instance Aeson.ToJSON LinkedEditingRangeOptions where
   toJSON (LinkedEditingRangeOptions arg0) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/LinkedEditingRangeParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/LinkedEditingRangeParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.LinkedEditingRangeParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -35,6 +37,7 @@ data LinkedEditingRangeParams = LinkedEditingRangeParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON LinkedEditingRangeParams)
 
 instance Aeson.ToJSON LinkedEditingRangeParams where
   toJSON (LinkedEditingRangeParams arg0 arg1 arg2) = Aeson.object $ concat $  [["textDocument" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/LinkedEditingRangeRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/LinkedEditingRangeRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.LinkedEditingRangeRegistrationOption
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -36,6 +38,7 @@ data LinkedEditingRangeRegistrationOptions = LinkedEditingRangeRegistrationOptio
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON LinkedEditingRangeRegistrationOptions)
 
 instance Aeson.ToJSON LinkedEditingRangeRegistrationOptions where
   toJSON (LinkedEditingRangeRegistrationOptions arg0 arg1 arg2) = Aeson.object $ concat $  [["documentSelector" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/LinkedEditingRanges.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/LinkedEditingRanges.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.LinkedEditingRanges where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -35,6 +37,7 @@ data LinkedEditingRanges = LinkedEditingRanges
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON LinkedEditingRanges)
 
 instance Aeson.ToJSON LinkedEditingRanges where
   toJSON (LinkedEditingRanges arg0 arg1) = Aeson.object $ concat $  [["ranges" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/Location.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/Location.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.Location where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -31,6 +33,7 @@ data Location = Location
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON Location)
 
 instance Aeson.ToJSON Location where
   toJSON (Location arg0 arg1) = Aeson.object $ concat $  [["uri" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/LocationLink.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/LocationLink.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.LocationLink where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -45,6 +47,7 @@ data LocationLink = LocationLink
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON LocationLink)
 
 instance Aeson.ToJSON LocationLink where
   toJSON (LocationLink arg0 arg1 arg2 arg3) = Aeson.object $ concat $  ["originSelectionRange" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/LogMessageParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/LogMessageParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.LogMessageParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -30,6 +32,7 @@ data LogMessageParams = LogMessageParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON LogMessageParams)
 
 instance Aeson.ToJSON LogMessageParams where
   toJSON (LogMessageParams arg0 arg1) = Aeson.object $ concat $  [["type" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/LogTraceParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/LogTraceParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.LogTraceParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -29,6 +31,7 @@ data LogTraceParams = LogTraceParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON LogTraceParams)
 
 instance Aeson.ToJSON LogTraceParams where
   toJSON (LogTraceParams arg0 arg1) = Aeson.object $ concat $  [["message" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/MarkdownClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/MarkdownClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.MarkdownClientCapabilities where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -38,6 +40,7 @@ data MarkdownClientCapabilities = MarkdownClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON MarkdownClientCapabilities)
 
 instance Aeson.ToJSON MarkdownClientCapabilities where
   toJSON (MarkdownClientCapabilities arg0 arg1 arg2) = Aeson.object $ concat $  [["parser" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/MarkedString.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/MarkedString.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.MarkedString where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row as Row
 import qualified Data.Row.Aeson as Aeson
@@ -34,3 +36,4 @@ newtype MarkedString = MarkedString (Data.Text.Text Language.LSP.Protocol.Types.
   deriving newtype (Aeson.ToJSON, Aeson.FromJSON)
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON MarkedString)

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/MarkupContent.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/MarkupContent.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.MarkupContent where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -51,6 +53,7 @@ data MarkupContent = MarkupContent
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON MarkupContent)
 
 instance Aeson.ToJSON MarkupContent where
   toJSON (MarkupContent arg0 arg1) = Aeson.object $ concat $  [["kind" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/MarkupKind.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/MarkupKind.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.MarkupKind where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -36,6 +38,7 @@ data MarkupKind =
   deriving anyclass (NFData, Hashable)
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum MarkupKind Data.Text.Text)
+  deriving Pretty via (ViaJSON MarkupKind)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum MarkupKind where
   knownValues = Data.Set.fromList [MarkupKind_PlainText,MarkupKind_Markdown]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/MessageActionItem.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/MessageActionItem.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.MessageActionItem where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -25,6 +27,7 @@ data MessageActionItem = MessageActionItem
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON MessageActionItem)
 
 instance Aeson.ToJSON MessageActionItem where
   toJSON (MessageActionItem arg0) = Aeson.object $ concat $  [["title" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/MessageType.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/MessageType.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.MessageType where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -40,6 +42,7 @@ data MessageType =
   deriving anyclass (NFData, Hashable)
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum MessageType Language.LSP.Protocol.Types.Common.UInt)
+  deriving Pretty via (ViaJSON MessageType)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum MessageType where
   knownValues = Data.Set.fromList [MessageType_Error

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/Moniker.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/Moniker.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.Moniker where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -42,6 +44,7 @@ data Moniker = Moniker
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON Moniker)
 
 instance Aeson.ToJSON Moniker where
   toJSON (Moniker arg0 arg1 arg2 arg3) = Aeson.object $ concat $  [["scheme" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/MonikerClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/MonikerClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.MonikerClientCapabilities where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -28,6 +30,7 @@ data MonikerClientCapabilities = MonikerClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON MonikerClientCapabilities)
 
 instance Aeson.ToJSON MonikerClientCapabilities where
   toJSON (MonikerClientCapabilities arg0) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/MonikerKind.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/MonikerKind.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.MonikerKind where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -39,6 +41,7 @@ data MonikerKind =
   deriving anyclass (NFData, Hashable)
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum MonikerKind Data.Text.Text)
+  deriving Pretty via (ViaJSON MonikerKind)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum MonikerKind where
   knownValues = Data.Set.fromList [MonikerKind_Import

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/MonikerOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/MonikerOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.MonikerOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -24,6 +26,7 @@ data MonikerOptions = MonikerOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON MonikerOptions)
 
 instance Aeson.ToJSON MonikerOptions where
   toJSON (MonikerOptions arg0) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/MonikerParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/MonikerParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.MonikerParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -40,6 +42,7 @@ data MonikerParams = MonikerParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON MonikerParams)
 
 instance Aeson.ToJSON MonikerParams where
   toJSON (MonikerParams arg0 arg1 arg2 arg3) = Aeson.object $ concat $  [["textDocument" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/MonikerRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/MonikerRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.MonikerRegistrationOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -30,6 +32,7 @@ data MonikerRegistrationOptions = MonikerRegistrationOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON MonikerRegistrationOptions)
 
 instance Aeson.ToJSON MonikerRegistrationOptions where
   toJSON (MonikerRegistrationOptions arg0 arg1) = Aeson.object $ concat $  [["documentSelector" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/NotebookCell.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/NotebookCell.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.NotebookCell where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
@@ -50,6 +52,7 @@ data NotebookCell = NotebookCell
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON NotebookCell)
 
 instance Aeson.ToJSON NotebookCell where
   toJSON (NotebookCell arg0 arg1 arg2 arg3) = Aeson.object $ concat $  [["kind" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/NotebookCellArrayChange.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/NotebookCellArrayChange.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.NotebookCellArrayChange where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -36,6 +38,7 @@ data NotebookCellArrayChange = NotebookCellArrayChange
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON NotebookCellArrayChange)
 
 instance Aeson.ToJSON NotebookCellArrayChange where
   toJSON (NotebookCellArrayChange arg0 arg1 arg2) = Aeson.object $ concat $  [["start" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/NotebookCellKind.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/NotebookCellKind.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.NotebookCellKind where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -34,6 +36,7 @@ data NotebookCellKind =
   deriving anyclass (NFData, Hashable)
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum NotebookCellKind Language.LSP.Protocol.Types.Common.UInt)
+  deriving Pretty via (ViaJSON NotebookCellKind)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum NotebookCellKind where
   knownValues = Data.Set.fromList [NotebookCellKind_Markup

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/NotebookCellTextDocumentFilter.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/NotebookCellTextDocumentFilter.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.NotebookCellTextDocumentFilter where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -39,6 +41,7 @@ data NotebookCellTextDocumentFilter = NotebookCellTextDocumentFilter
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON NotebookCellTextDocumentFilter)
 
 instance Aeson.ToJSON NotebookCellTextDocumentFilter where
   toJSON (NotebookCellTextDocumentFilter arg0 arg1) = Aeson.object $ concat $  [["notebook" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/NotebookDocument.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/NotebookDocument.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.NotebookDocument where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
@@ -50,6 +52,7 @@ data NotebookDocument = NotebookDocument
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON NotebookDocument)
 
 instance Aeson.ToJSON NotebookDocument where
   toJSON (NotebookDocument arg0 arg1 arg2 arg3 arg4) = Aeson.object $ concat $  [["uri" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/NotebookDocumentChangeEvent.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/NotebookDocumentChangeEvent.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.NotebookDocumentChangeEvent where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson
 import qualified Data.Aeson as Aeson
 import qualified Data.Row as Row
@@ -40,6 +42,7 @@ data NotebookDocumentChangeEvent = NotebookDocumentChangeEvent
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON NotebookDocumentChangeEvent)
 
 instance Aeson.ToJSON NotebookDocumentChangeEvent where
   toJSON (NotebookDocumentChangeEvent arg0 arg1) = Aeson.object $ concat $  ["metadata" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/NotebookDocumentClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/NotebookDocumentClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.NotebookDocumentClientCapabilities w
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -29,6 +31,7 @@ data NotebookDocumentClientCapabilities = NotebookDocumentClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON NotebookDocumentClientCapabilities)
 
 instance Aeson.ToJSON NotebookDocumentClientCapabilities where
   toJSON (NotebookDocumentClientCapabilities arg0) = Aeson.object $ concat $  [["synchronization" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/NotebookDocumentFilter.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/NotebookDocumentFilter.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.NotebookDocumentFilter where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row as Row
 import qualified Data.Row.Aeson as Aeson
@@ -26,3 +28,4 @@ newtype NotebookDocumentFilter = NotebookDocumentFilter ((Row.Rec ("notebookType
   deriving newtype (Aeson.ToJSON, Aeson.FromJSON)
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON NotebookDocumentFilter)

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/NotebookDocumentIdentifier.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/NotebookDocumentIdentifier.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.NotebookDocumentIdentifier where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -27,6 +29,7 @@ data NotebookDocumentIdentifier = NotebookDocumentIdentifier
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON NotebookDocumentIdentifier)
 
 instance Aeson.ToJSON NotebookDocumentIdentifier where
   toJSON (NotebookDocumentIdentifier arg0) = Aeson.object $ concat $  [["uri" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/NotebookDocumentSyncClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/NotebookDocumentSyncClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.NotebookDocumentSyncClientCapabiliti
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -33,6 +35,7 @@ data NotebookDocumentSyncClientCapabilities = NotebookDocumentSyncClientCapabili
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON NotebookDocumentSyncClientCapabilities)
 
 instance Aeson.ToJSON NotebookDocumentSyncClientCapabilities where
   toJSON (NotebookDocumentSyncClientCapabilities arg0 arg1) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/NotebookDocumentSyncOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/NotebookDocumentSyncOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.NotebookDocumentSyncOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row as Row
 import qualified Data.Row.Aeson as Aeson
@@ -44,6 +46,7 @@ data NotebookDocumentSyncOptions = NotebookDocumentSyncOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON NotebookDocumentSyncOptions)
 
 instance Aeson.ToJSON NotebookDocumentSyncOptions where
   toJSON (NotebookDocumentSyncOptions arg0 arg1) = Aeson.object $ concat $  [["notebookSelector" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/NotebookDocumentSyncRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/NotebookDocumentSyncRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.NotebookDocumentSyncRegistrationOpti
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row as Row
 import qualified Data.Row.Aeson as Aeson
@@ -39,6 +41,7 @@ data NotebookDocumentSyncRegistrationOptions = NotebookDocumentSyncRegistrationO
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON NotebookDocumentSyncRegistrationOptions)
 
 instance Aeson.ToJSON NotebookDocumentSyncRegistrationOptions where
   toJSON (NotebookDocumentSyncRegistrationOptions arg0 arg1 arg2) = Aeson.object $ concat $  [["notebookSelector" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/OptionalVersionedTextDocumentIdentifier.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/OptionalVersionedTextDocumentIdentifier.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.OptionalVersionedTextDocumentIdentif
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -33,6 +35,7 @@ data OptionalVersionedTextDocumentIdentifier = OptionalVersionedTextDocumentIden
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON OptionalVersionedTextDocumentIdentifier)
 
 instance Aeson.ToJSON OptionalVersionedTextDocumentIdentifier where
   toJSON (OptionalVersionedTextDocumentIdentifier arg0 arg1) = Aeson.object $ concat $  [["uri" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ParameterInformation.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ParameterInformation.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ParameterInformation where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -40,6 +42,7 @@ data ParameterInformation = ParameterInformation
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ParameterInformation)
 
 instance Aeson.ToJSON ParameterInformation where
   toJSON (ParameterInformation arg0 arg1) = Aeson.object $ concat $  [["label" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/PartialResultParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/PartialResultParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.PartialResultParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -26,6 +28,7 @@ data PartialResultParams = PartialResultParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON PartialResultParams)
 
 instance Aeson.ToJSON PartialResultParams where
   toJSON (PartialResultParams arg0) = Aeson.object $ concat $  ["partialResultToken" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/Pattern.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/Pattern.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.Pattern where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -31,3 +33,4 @@ newtype Pattern = Pattern Data.Text.Text
   , Aeson.FromJSONKey )
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON Pattern)

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/Position.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/Position.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.Position where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -63,6 +65,7 @@ data Position = Position
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON Position)
 
 instance Aeson.ToJSON Position where
   toJSON (Position arg0 arg1) = Aeson.object $ concat $  [["line" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/PositionEncodingKind.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/PositionEncodingKind.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.PositionEncodingKind where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -47,6 +49,7 @@ data PositionEncodingKind =
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON
   , Data.String.IsString ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum PositionEncodingKind Data.Text.Text)
+  deriving Pretty via (ViaJSON PositionEncodingKind)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum PositionEncodingKind where
   knownValues = Data.Set.fromList [PositionEncodingKind_UTF8

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/PrepareRenameParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/PrepareRenameParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.PrepareRenameParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -35,6 +37,7 @@ data PrepareRenameParams = PrepareRenameParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON PrepareRenameParams)
 
 instance Aeson.ToJSON PrepareRenameParams where
   toJSON (PrepareRenameParams arg0 arg1 arg2) = Aeson.object $ concat $  [["textDocument" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/PrepareRenameResult.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/PrepareRenameResult.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.PrepareRenameResult where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row as Row
 import qualified Data.Row.Aeson as Aeson
@@ -23,3 +25,4 @@ newtype PrepareRenameResult = PrepareRenameResult (Language.LSP.Protocol.Interna
   deriving newtype (Aeson.ToJSON, Aeson.FromJSON)
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON PrepareRenameResult)

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/PrepareSupportDefaultBehavior.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/PrepareSupportDefaultBehavior.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.PrepareSupportDefaultBehavior where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -29,6 +31,7 @@ data PrepareSupportDefaultBehavior =
   deriving anyclass (NFData, Hashable)
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum PrepareSupportDefaultBehavior Language.LSP.Protocol.Types.Common.UInt)
+  deriving Pretty via (ViaJSON PrepareSupportDefaultBehavior)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum PrepareSupportDefaultBehavior where
   knownValues = Data.Set.fromList [PrepareSupportDefaultBehavior_Identifier]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/PreviousResultId.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/PreviousResultId.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.PreviousResultId where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -33,6 +35,7 @@ data PreviousResultId = PreviousResultId
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON PreviousResultId)
 
 instance Aeson.ToJSON PreviousResultId where
   toJSON (PreviousResultId arg0 arg1) = Aeson.object $ concat $  [["uri" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ProgressParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ProgressParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ProgressParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
@@ -30,6 +32,7 @@ data ProgressParams = ProgressParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ProgressParams)
 
 instance Aeson.ToJSON ProgressParams where
   toJSON (ProgressParams arg0 arg1) = Aeson.object $ concat $  [["token" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ProgressToken.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ProgressToken.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ProgressToken where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -21,3 +23,4 @@ newtype ProgressToken = ProgressToken (Language.LSP.Protocol.Types.Common.Int32 
   deriving newtype (Aeson.ToJSON, Aeson.FromJSON)
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ProgressToken)

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/PublishDiagnosticsClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/PublishDiagnosticsClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.PublishDiagnosticsClientCapabilities
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row as Row
 import qualified Data.Row.Aeson as Aeson
@@ -54,6 +56,7 @@ data PublishDiagnosticsClientCapabilities = PublishDiagnosticsClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON PublishDiagnosticsClientCapabilities)
 
 instance Aeson.ToJSON PublishDiagnosticsClientCapabilities where
   toJSON (PublishDiagnosticsClientCapabilities arg0 arg1 arg2 arg3 arg4) = Aeson.object $ concat $  ["relatedInformation" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/PublishDiagnosticsParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/PublishDiagnosticsParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.PublishDiagnosticsParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -36,6 +38,7 @@ data PublishDiagnosticsParams = PublishDiagnosticsParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON PublishDiagnosticsParams)
 
 instance Aeson.ToJSON PublishDiagnosticsParams where
   toJSON (PublishDiagnosticsParams arg0 arg1 arg2) = Aeson.object $ concat $  [["uri" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/Range.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/Range.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.Range where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -39,6 +41,7 @@ data Range = Range
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON Range)
 
 instance Aeson.ToJSON Range where
   toJSON (Range arg0 arg1) = Aeson.object $ concat $  [["start" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ReferenceClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ReferenceClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ReferenceClientCapabilities where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -24,6 +26,7 @@ data ReferenceClientCapabilities = ReferenceClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ReferenceClientCapabilities)
 
 instance Aeson.ToJSON ReferenceClientCapabilities where
   toJSON (ReferenceClientCapabilities arg0) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ReferenceContext.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ReferenceContext.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ReferenceContext where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -25,6 +27,7 @@ data ReferenceContext = ReferenceContext
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ReferenceContext)
 
 instance Aeson.ToJSON ReferenceContext where
   toJSON (ReferenceContext arg0) = Aeson.object $ concat $  [["includeDeclaration" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ReferenceOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ReferenceOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ReferenceOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -24,6 +26,7 @@ data ReferenceOptions = ReferenceOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ReferenceOptions)
 
 instance Aeson.ToJSON ReferenceOptions where
   toJSON (ReferenceOptions arg0) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ReferenceParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ReferenceParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ReferenceParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -45,6 +47,7 @@ data ReferenceParams = ReferenceParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ReferenceParams)
 
 instance Aeson.ToJSON ReferenceParams where
   toJSON (ReferenceParams arg0 arg1 arg2 arg3 arg4) = Aeson.object $ concat $  [["textDocument" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ReferenceRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ReferenceRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ReferenceRegistrationOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -30,6 +32,7 @@ data ReferenceRegistrationOptions = ReferenceRegistrationOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ReferenceRegistrationOptions)
 
 instance Aeson.ToJSON ReferenceRegistrationOptions where
   toJSON (ReferenceRegistrationOptions arg0 arg1) = Aeson.object $ concat $  [["documentSelector" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/Registration.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/Registration.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.Registration where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
@@ -35,6 +37,7 @@ data Registration = Registration
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON Registration)
 
 instance Aeson.ToJSON Registration where
   toJSON (Registration arg0 arg1 arg2) = Aeson.object $ concat $  [["id" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/RegistrationParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/RegistrationParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.RegistrationParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -25,6 +27,7 @@ data RegistrationParams = RegistrationParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON RegistrationParams)
 
 instance Aeson.ToJSON RegistrationParams where
   toJSON (RegistrationParams arg0) = Aeson.object $ concat $  [["registrations" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/RegularExpressionsClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/RegularExpressionsClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.RegularExpressionsClientCapabilities
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -31,6 +33,7 @@ data RegularExpressionsClientCapabilities = RegularExpressionsClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON RegularExpressionsClientCapabilities)
 
 instance Aeson.ToJSON RegularExpressionsClientCapabilities where
   toJSON (RegularExpressionsClientCapabilities arg0 arg1) = Aeson.object $ concat $  [["engine" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/RelatedFullDocumentDiagnosticReport.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/RelatedFullDocumentDiagnosticReport.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.RelatedFullDocumentDiagnosticReport 
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Map
 import qualified Data.Row.Aeson as Aeson
@@ -53,6 +55,7 @@ data RelatedFullDocumentDiagnosticReport = RelatedFullDocumentDiagnosticReport
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON RelatedFullDocumentDiagnosticReport)
 
 instance Aeson.ToJSON RelatedFullDocumentDiagnosticReport where
   toJSON (RelatedFullDocumentDiagnosticReport arg0 arg1 arg2 arg3) = Aeson.object $ concat $  [["kind" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/RelatedUnchangedDocumentDiagnosticReport.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/RelatedUnchangedDocumentDiagnosticReport.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.RelatedUnchangedDocumentDiagnosticRe
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Map
 import qualified Data.Row.Aeson as Aeson
@@ -50,6 +52,7 @@ data RelatedUnchangedDocumentDiagnosticReport = RelatedUnchangedDocumentDiagnost
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON RelatedUnchangedDocumentDiagnosticReport)
 
 instance Aeson.ToJSON RelatedUnchangedDocumentDiagnosticReport where
   toJSON (RelatedUnchangedDocumentDiagnosticReport arg0 arg1 arg2) = Aeson.object $ concat $  [["kind" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/RelativePattern.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/RelativePattern.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.RelativePattern where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -36,6 +38,7 @@ data RelativePattern = RelativePattern
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON RelativePattern)
 
 instance Aeson.ToJSON RelativePattern where
   toJSON (RelativePattern arg0 arg1) = Aeson.object $ concat $  [["baseUri" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/RenameClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/RenameClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.RenameClientCapabilities where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -51,6 +53,7 @@ data RenameClientCapabilities = RenameClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON RenameClientCapabilities)
 
 instance Aeson.ToJSON RenameClientCapabilities where
   toJSON (RenameClientCapabilities arg0 arg1 arg2 arg3) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/RenameFile.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/RenameFile.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.RenameFile where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -46,6 +48,7 @@ data RenameFile = RenameFile
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON RenameFile)
 
 instance Aeson.ToJSON RenameFile where
   toJSON (RenameFile arg0 arg1 arg2 arg3 arg4) = Aeson.object $ concat $  ["annotationId" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/RenameFileOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/RenameFileOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.RenameFileOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -28,6 +30,7 @@ data RenameFileOptions = RenameFileOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON RenameFileOptions)
 
 instance Aeson.ToJSON RenameFileOptions where
   toJSON (RenameFileOptions arg0 arg1) = Aeson.object $ concat $  ["overwrite" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/RenameFilesParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/RenameFilesParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.RenameFilesParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -29,6 +31,7 @@ data RenameFilesParams = RenameFilesParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON RenameFilesParams)
 
 instance Aeson.ToJSON RenameFilesParams where
   toJSON (RenameFilesParams arg0) = Aeson.object $ concat $  [["files" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/RenameOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/RenameOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.RenameOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -30,6 +32,7 @@ data RenameOptions = RenameOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON RenameOptions)
 
 instance Aeson.ToJSON RenameOptions where
   toJSON (RenameOptions arg0 arg1) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/RenameParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/RenameParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.RenameParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -42,6 +44,7 @@ data RenameParams = RenameParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON RenameParams)
 
 instance Aeson.ToJSON RenameParams where
   toJSON (RenameParams arg0 arg1 arg2 arg3) = Aeson.object $ concat $  ["workDoneToken" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/RenameRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/RenameRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.RenameRegistrationOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -36,6 +38,7 @@ data RenameRegistrationOptions = RenameRegistrationOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON RenameRegistrationOptions)
 
 instance Aeson.ToJSON RenameRegistrationOptions where
   toJSON (RenameRegistrationOptions arg0 arg1 arg2) = Aeson.object $ concat $  [["documentSelector" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ResourceOperation.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ResourceOperation.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ResourceOperation where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -32,6 +34,7 @@ data ResourceOperation = ResourceOperation
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ResourceOperation)
 
 instance Aeson.ToJSON ResourceOperation where
   toJSON (ResourceOperation arg0 arg1) = Aeson.object $ concat $  [["kind" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ResourceOperationKind.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ResourceOperationKind.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ResourceOperationKind where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -36,6 +38,7 @@ data ResourceOperationKind =
   deriving anyclass (NFData, Hashable)
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum ResourceOperationKind Data.Text.Text)
+  deriving Pretty via (ViaJSON ResourceOperationKind)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum ResourceOperationKind where
   knownValues = Data.Set.fromList [ResourceOperationKind_Create

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SaveOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SaveOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.SaveOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -24,6 +26,7 @@ data SaveOptions = SaveOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON SaveOptions)
 
 instance Aeson.ToJSON SaveOptions where
   toJSON (SaveOptions arg0) = Aeson.object $ concat $  ["includeText" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SelectionRange.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SelectionRange.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.SelectionRange where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -30,6 +32,7 @@ data SelectionRange = SelectionRange
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON SelectionRange)
 
 instance Aeson.ToJSON SelectionRange where
   toJSON (SelectionRange arg0 arg1) = Aeson.object $ concat $  [["range" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SelectionRangeClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SelectionRangeClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.SelectionRangeClientCapabilities whe
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -26,6 +28,7 @@ data SelectionRangeClientCapabilities = SelectionRangeClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON SelectionRangeClientCapabilities)
 
 instance Aeson.ToJSON SelectionRangeClientCapabilities where
   toJSON (SelectionRangeClientCapabilities arg0) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SelectionRangeOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SelectionRangeOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.SelectionRangeOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -24,6 +26,7 @@ data SelectionRangeOptions = SelectionRangeOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON SelectionRangeOptions)
 
 instance Aeson.ToJSON SelectionRangeOptions where
   toJSON (SelectionRangeOptions arg0) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SelectionRangeParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SelectionRangeParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.SelectionRangeParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -40,6 +42,7 @@ data SelectionRangeParams = SelectionRangeParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON SelectionRangeParams)
 
 instance Aeson.ToJSON SelectionRangeParams where
   toJSON (SelectionRangeParams arg0 arg1 arg2 arg3) = Aeson.object $ concat $  ["workDoneToken" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SelectionRangeRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SelectionRangeRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.SelectionRangeRegistrationOptions wh
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -36,6 +38,7 @@ data SelectionRangeRegistrationOptions = SelectionRangeRegistrationOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON SelectionRangeRegistrationOptions)
 
 instance Aeson.ToJSON SelectionRangeRegistrationOptions where
   toJSON (SelectionRangeRegistrationOptions arg0 arg1 arg2) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SemanticTokenModifiers.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SemanticTokenModifiers.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.SemanticTokenModifiers where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -70,6 +72,7 @@ data SemanticTokenModifiers =
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON
   , Data.String.IsString ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum SemanticTokenModifiers Data.Text.Text)
+  deriving Pretty via (ViaJSON SemanticTokenModifiers)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum SemanticTokenModifiers where
   knownValues = Data.Set.fromList [SemanticTokenModifiers_Declaration

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SemanticTokenTypes.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SemanticTokenTypes.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.SemanticTokenTypes where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -123,6 +125,7 @@ data SemanticTokenTypes =
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON
   , Data.String.IsString ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum SemanticTokenTypes Data.Text.Text)
+  deriving Pretty via (ViaJSON SemanticTokenTypes)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum SemanticTokenTypes where
   knownValues = Data.Set.fromList [SemanticTokenTypes_Namespace

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SemanticTokens.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SemanticTokens.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.SemanticTokens where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -32,6 +34,7 @@ data SemanticTokens = SemanticTokens
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON SemanticTokens)
 
 instance Aeson.ToJSON SemanticTokens where
   toJSON (SemanticTokens arg0 arg1) = Aeson.object $ concat $  ["resultId" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SemanticTokensClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SemanticTokensClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.SemanticTokensClientCapabilities whe
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row as Row
 import qualified Data.Row.Aeson as Aeson
@@ -82,6 +84,7 @@ data SemanticTokensClientCapabilities = SemanticTokensClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON SemanticTokensClientCapabilities)
 
 instance Aeson.ToJSON SemanticTokensClientCapabilities where
   toJSON (SemanticTokensClientCapabilities arg0 arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SemanticTokensDelta.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SemanticTokensDelta.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.SemanticTokensDelta where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -30,6 +32,7 @@ data SemanticTokensDelta = SemanticTokensDelta
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON SemanticTokensDelta)
 
 instance Aeson.ToJSON SemanticTokensDelta where
   toJSON (SemanticTokensDelta arg0 arg1) = Aeson.object $ concat $  ["resultId" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SemanticTokensDeltaParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SemanticTokensDeltaParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.SemanticTokensDeltaParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -41,6 +43,7 @@ data SemanticTokensDeltaParams = SemanticTokensDeltaParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON SemanticTokensDeltaParams)
 
 instance Aeson.ToJSON SemanticTokensDeltaParams where
   toJSON (SemanticTokensDeltaParams arg0 arg1 arg2 arg3) = Aeson.object $ concat $  ["workDoneToken" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SemanticTokensDeltaPartialResult.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SemanticTokensDeltaPartialResult.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.SemanticTokensDeltaPartialResult whe
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -25,6 +27,7 @@ data SemanticTokensDeltaPartialResult = SemanticTokensDeltaPartialResult
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON SemanticTokensDeltaPartialResult)
 
 instance Aeson.ToJSON SemanticTokensDeltaPartialResult where
   toJSON (SemanticTokensDeltaPartialResult arg0) = Aeson.object $ concat $  [["edits" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SemanticTokensEdit.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SemanticTokensEdit.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.SemanticTokensEdit where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -32,6 +34,7 @@ data SemanticTokensEdit = SemanticTokensEdit
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON SemanticTokensEdit)
 
 instance Aeson.ToJSON SemanticTokensEdit where
   toJSON (SemanticTokensEdit arg0 arg1 arg2) = Aeson.object $ concat $  [["start" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SemanticTokensLegend.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SemanticTokensLegend.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.SemanticTokensLegend where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -29,6 +31,7 @@ data SemanticTokensLegend = SemanticTokensLegend
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON SemanticTokensLegend)
 
 instance Aeson.ToJSON SemanticTokensLegend where
   toJSON (SemanticTokensLegend arg0 arg1) = Aeson.object $ concat $  [["tokenTypes" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SemanticTokensOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SemanticTokensOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.SemanticTokensOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row as Row
 import qualified Data.Row.Aeson as Aeson
@@ -39,6 +41,7 @@ data SemanticTokensOptions = SemanticTokensOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON SemanticTokensOptions)
 
 instance Aeson.ToJSON SemanticTokensOptions where
   toJSON (SemanticTokensOptions arg0 arg1 arg2 arg3) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SemanticTokensParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SemanticTokensParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.SemanticTokensParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -35,6 +37,7 @@ data SemanticTokensParams = SemanticTokensParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON SemanticTokensParams)
 
 instance Aeson.ToJSON SemanticTokensParams where
   toJSON (SemanticTokensParams arg0 arg1 arg2) = Aeson.object $ concat $  ["workDoneToken" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SemanticTokensPartialResult.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SemanticTokensPartialResult.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.SemanticTokensPartialResult where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -24,6 +26,7 @@ data SemanticTokensPartialResult = SemanticTokensPartialResult
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON SemanticTokensPartialResult)
 
 instance Aeson.ToJSON SemanticTokensPartialResult where
   toJSON (SemanticTokensPartialResult arg0) = Aeson.object $ concat $  [["data" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SemanticTokensRangeParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SemanticTokensRangeParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.SemanticTokensRangeParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -40,6 +42,7 @@ data SemanticTokensRangeParams = SemanticTokensRangeParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON SemanticTokensRangeParams)
 
 instance Aeson.ToJSON SemanticTokensRangeParams where
   toJSON (SemanticTokensRangeParams arg0 arg1 arg2 arg3) = Aeson.object $ concat $  ["workDoneToken" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SemanticTokensRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SemanticTokensRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.SemanticTokensRegistrationOptions wh
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row as Row
 import qualified Data.Row.Aeson as Aeson
@@ -51,6 +53,7 @@ data SemanticTokensRegistrationOptions = SemanticTokensRegistrationOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON SemanticTokensRegistrationOptions)
 
 instance Aeson.ToJSON SemanticTokensRegistrationOptions where
   toJSON (SemanticTokensRegistrationOptions arg0 arg1 arg2 arg3 arg4 arg5) = Aeson.object $ concat $  [["documentSelector" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SemanticTokensWorkspaceClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SemanticTokensWorkspaceClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.SemanticTokensWorkspaceClientCapabil
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -30,6 +32,7 @@ data SemanticTokensWorkspaceClientCapabilities = SemanticTokensWorkspaceClientCa
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON SemanticTokensWorkspaceClientCapabilities)
 
 instance Aeson.ToJSON SemanticTokensWorkspaceClientCapabilities where
   toJSON (SemanticTokensWorkspaceClientCapabilities arg0) = Aeson.object $ concat $  ["refreshSupport" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ServerCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ServerCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ServerCapabilities where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson
 import qualified Data.Aeson as Aeson
 import qualified Data.Row as Row
@@ -246,6 +248,7 @@ data ServerCapabilities = ServerCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ServerCapabilities)
 
 instance Aeson.ToJSON ServerCapabilities where
   toJSON (ServerCapabilities arg0 arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14 arg15 arg16 arg17 arg18 arg19 arg20 arg21 arg22 arg23 arg24 arg25 arg26 arg27 arg28 arg29 arg30 arg31 arg32 arg33 arg34) = Aeson.object $ concat $  ["positionEncoding" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SetTraceParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SetTraceParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.SetTraceParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -25,6 +27,7 @@ data SetTraceParams = SetTraceParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON SetTraceParams)
 
 instance Aeson.ToJSON SetTraceParams where
   toJSON (SetTraceParams arg0) = Aeson.object $ concat $  [["value" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ShowDocumentClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ShowDocumentClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ShowDocumentClientCapabilities where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -27,6 +29,7 @@ data ShowDocumentClientCapabilities = ShowDocumentClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ShowDocumentClientCapabilities)
 
 instance Aeson.ToJSON ShowDocumentClientCapabilities where
   toJSON (ShowDocumentClientCapabilities arg0) = Aeson.object $ concat $  [["support" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ShowDocumentParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ShowDocumentParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ShowDocumentParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -48,6 +50,7 @@ data ShowDocumentParams = ShowDocumentParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ShowDocumentParams)
 
 instance Aeson.ToJSON ShowDocumentParams where
   toJSON (ShowDocumentParams arg0 arg1 arg2 arg3) = Aeson.object $ concat $  [["uri" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ShowDocumentResult.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ShowDocumentResult.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ShowDocumentResult where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -26,6 +28,7 @@ data ShowDocumentResult = ShowDocumentResult
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ShowDocumentResult)
 
 instance Aeson.ToJSON ShowDocumentResult where
   toJSON (ShowDocumentResult arg0) = Aeson.object $ concat $  [["success" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ShowMessageParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ShowMessageParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ShowMessageParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -30,6 +32,7 @@ data ShowMessageParams = ShowMessageParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ShowMessageParams)
 
 instance Aeson.ToJSON ShowMessageParams where
   toJSON (ShowMessageParams arg0 arg1) = Aeson.object $ concat $  [["type" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ShowMessageRequestClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ShowMessageRequestClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ShowMessageRequestClientCapabilities
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row as Row
 import qualified Data.Row.Aeson as Aeson
@@ -25,6 +27,7 @@ data ShowMessageRequestClientCapabilities = ShowMessageRequestClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ShowMessageRequestClientCapabilities)
 
 instance Aeson.ToJSON ShowMessageRequestClientCapabilities where
   toJSON (ShowMessageRequestClientCapabilities arg0) = Aeson.object $ concat $  ["messageActionItem" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ShowMessageRequestParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/ShowMessageRequestParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.ShowMessageRequestParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -35,6 +37,7 @@ data ShowMessageRequestParams = ShowMessageRequestParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON ShowMessageRequestParams)
 
 instance Aeson.ToJSON ShowMessageRequestParams where
   toJSON (ShowMessageRequestParams arg0 arg1 arg2) = Aeson.object $ concat $  [["type" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SignatureHelp.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SignatureHelp.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.SignatureHelp where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -49,6 +51,7 @@ data SignatureHelp = SignatureHelp
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON SignatureHelp)
 
 instance Aeson.ToJSON SignatureHelp where
   toJSON (SignatureHelp arg0 arg1 arg2) = Aeson.object $ concat $  [["signatures" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SignatureHelpClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SignatureHelpClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.SignatureHelpClientCapabilities wher
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row as Row
 import qualified Data.Row.Aeson as Aeson
@@ -40,6 +42,7 @@ data SignatureHelpClientCapabilities = SignatureHelpClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON SignatureHelpClientCapabilities)
 
 instance Aeson.ToJSON SignatureHelpClientCapabilities where
   toJSON (SignatureHelpClientCapabilities arg0 arg1 arg2) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SignatureHelpContext.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SignatureHelpContext.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.SignatureHelpContext where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -49,6 +51,7 @@ data SignatureHelpContext = SignatureHelpContext
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON SignatureHelpContext)
 
 instance Aeson.ToJSON SignatureHelpContext where
   toJSON (SignatureHelpContext arg0 arg1 arg2 arg3) = Aeson.object $ concat $  [["triggerKind" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SignatureHelpOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SignatureHelpOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.SignatureHelpOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -38,6 +40,7 @@ data SignatureHelpOptions = SignatureHelpOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON SignatureHelpOptions)
 
 instance Aeson.ToJSON SignatureHelpOptions where
   toJSON (SignatureHelpOptions arg0 arg1 arg2) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SignatureHelpParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SignatureHelpParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.SignatureHelpParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -43,6 +45,7 @@ data SignatureHelpParams = SignatureHelpParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON SignatureHelpParams)
 
 instance Aeson.ToJSON SignatureHelpParams where
   toJSON (SignatureHelpParams arg0 arg1 arg2 arg3) = Aeson.object $ concat $  [["textDocument" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SignatureHelpRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SignatureHelpRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.SignatureHelpRegistrationOptions whe
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -44,6 +46,7 @@ data SignatureHelpRegistrationOptions = SignatureHelpRegistrationOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON SignatureHelpRegistrationOptions)
 
 instance Aeson.ToJSON SignatureHelpRegistrationOptions where
   toJSON (SignatureHelpRegistrationOptions arg0 arg1 arg2 arg3) = Aeson.object $ concat $  [["documentSelector" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SignatureHelpTriggerKind.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SignatureHelpTriggerKind.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.SignatureHelpTriggerKind where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -38,6 +40,7 @@ data SignatureHelpTriggerKind =
   deriving anyclass (NFData, Hashable)
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum SignatureHelpTriggerKind Language.LSP.Protocol.Types.Common.UInt)
+  deriving Pretty via (ViaJSON SignatureHelpTriggerKind)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum SignatureHelpTriggerKind where
   knownValues = Data.Set.fromList [SignatureHelpTriggerKind_Invoked

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SignatureInformation.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SignatureInformation.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.SignatureInformation where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -47,6 +49,7 @@ data SignatureInformation = SignatureInformation
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON SignatureInformation)
 
 instance Aeson.ToJSON SignatureInformation where
   toJSON (SignatureInformation arg0 arg1 arg2 arg3) = Aeson.object $ concat $  [["label" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/StaticRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/StaticRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.StaticRegistrationOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -27,6 +29,7 @@ data StaticRegistrationOptions = StaticRegistrationOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON StaticRegistrationOptions)
 
 instance Aeson.ToJSON StaticRegistrationOptions where
   toJSON (StaticRegistrationOptions arg0) = Aeson.object $ concat $  ["id" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SymbolInformation.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SymbolInformation.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.SymbolInformation where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -64,6 +66,7 @@ data SymbolInformation = SymbolInformation
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON SymbolInformation)
 
 instance Aeson.ToJSON SymbolInformation where
   toJSON (SymbolInformation arg0 arg1 arg2 arg3 arg4 arg5) = Aeson.object $ concat $  [["name" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SymbolKind.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SymbolKind.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.SymbolKind where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -128,6 +130,7 @@ data SymbolKind =
   deriving anyclass (NFData, Hashable)
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum SymbolKind Language.LSP.Protocol.Types.Common.UInt)
+  deriving Pretty via (ViaJSON SymbolKind)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum SymbolKind where
   knownValues = Data.Set.fromList [SymbolKind_File

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SymbolTag.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/SymbolTag.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.SymbolTag where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -30,6 +32,7 @@ data SymbolTag =
   deriving anyclass (NFData, Hashable)
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum SymbolTag Language.LSP.Protocol.Types.Common.UInt)
+  deriving Pretty via (ViaJSON SymbolTag)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum SymbolTag where
   knownValues = Data.Set.fromList [SymbolTag_Deprecated]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TextDocumentChangeRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TextDocumentChangeRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.TextDocumentChangeRegistrationOption
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -31,6 +33,7 @@ data TextDocumentChangeRegistrationOptions = TextDocumentChangeRegistrationOptio
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON TextDocumentChangeRegistrationOptions)
 
 instance Aeson.ToJSON TextDocumentChangeRegistrationOptions where
   toJSON (TextDocumentChangeRegistrationOptions arg0 arg1) = Aeson.object $ concat $  [["documentSelector" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TextDocumentClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TextDocumentClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.TextDocumentClientCapabilities where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -199,6 +201,7 @@ data TextDocumentClientCapabilities = TextDocumentClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON TextDocumentClientCapabilities)
 
 instance Aeson.ToJSON TextDocumentClientCapabilities where
   toJSON (TextDocumentClientCapabilities arg0 arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14 arg15 arg16 arg17 arg18 arg19 arg20 arg21 arg22 arg23 arg24 arg25 arg26 arg27 arg28 arg29) = Aeson.object $ concat $  ["synchronization" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TextDocumentContentChangeEvent.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TextDocumentContentChangeEvent.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.TextDocumentContentChangeEvent where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row as Row
 import qualified Data.Row.Aeson as Aeson
@@ -24,3 +26,4 @@ newtype TextDocumentContentChangeEvent = TextDocumentContentChangeEvent ((Row.Re
   deriving newtype (Aeson.ToJSON, Aeson.FromJSON)
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON TextDocumentContentChangeEvent)

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TextDocumentEdit.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TextDocumentEdit.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.TextDocumentEdit where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -37,6 +39,7 @@ data TextDocumentEdit = TextDocumentEdit
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON TextDocumentEdit)
 
 instance Aeson.ToJSON TextDocumentEdit where
   toJSON (TextDocumentEdit arg0 arg1) = Aeson.object $ concat $  [["textDocument" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TextDocumentFilter.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TextDocumentFilter.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.TextDocumentFilter where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row as Row
 import qualified Data.Row.Aeson as Aeson
@@ -37,3 +39,4 @@ newtype TextDocumentFilter = TextDocumentFilter ((Row.Rec ("language" Row..== Da
   deriving newtype (Aeson.ToJSON, Aeson.FromJSON)
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON TextDocumentFilter)

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TextDocumentIdentifier.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TextDocumentIdentifier.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.TextDocumentIdentifier where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -25,6 +27,7 @@ data TextDocumentIdentifier = TextDocumentIdentifier
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON TextDocumentIdentifier)
 
 instance Aeson.ToJSON TextDocumentIdentifier where
   toJSON (TextDocumentIdentifier arg0) = Aeson.object $ concat $  [["uri" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TextDocumentItem.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TextDocumentItem.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.TextDocumentItem where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -40,6 +42,7 @@ data TextDocumentItem = TextDocumentItem
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON TextDocumentItem)
 
 instance Aeson.ToJSON TextDocumentItem where
   toJSON (TextDocumentItem arg0 arg1 arg2 arg3) = Aeson.object $ concat $  [["uri" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TextDocumentPositionParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TextDocumentPositionParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.TextDocumentPositionParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -31,6 +33,7 @@ data TextDocumentPositionParams = TextDocumentPositionParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON TextDocumentPositionParams)
 
 instance Aeson.ToJSON TextDocumentPositionParams where
   toJSON (TextDocumentPositionParams arg0 arg1) = Aeson.object $ concat $  [["textDocument" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TextDocumentRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TextDocumentRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.TextDocumentRegistrationOptions wher
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -26,6 +28,7 @@ data TextDocumentRegistrationOptions = TextDocumentRegistrationOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON TextDocumentRegistrationOptions)
 
 instance Aeson.ToJSON TextDocumentRegistrationOptions where
   toJSON (TextDocumentRegistrationOptions arg0) = Aeson.object $ concat $  [["documentSelector" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TextDocumentSaveReason.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TextDocumentSaveReason.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.TextDocumentSaveReason where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -37,6 +39,7 @@ data TextDocumentSaveReason =
   deriving anyclass (NFData, Hashable)
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum TextDocumentSaveReason Language.LSP.Protocol.Types.Common.UInt)
+  deriving Pretty via (ViaJSON TextDocumentSaveReason)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum TextDocumentSaveReason where
   knownValues = Data.Set.fromList [TextDocumentSaveReason_Manual

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TextDocumentSaveRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TextDocumentSaveRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.TextDocumentSaveRegistrationOptions 
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -30,6 +32,7 @@ data TextDocumentSaveRegistrationOptions = TextDocumentSaveRegistrationOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON TextDocumentSaveRegistrationOptions)
 
 instance Aeson.ToJSON TextDocumentSaveRegistrationOptions where
   toJSON (TextDocumentSaveRegistrationOptions arg0 arg1) = Aeson.object $ concat $  [["documentSelector" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TextDocumentSyncClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TextDocumentSyncClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.TextDocumentSyncClientCapabilities w
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -38,6 +40,7 @@ data TextDocumentSyncClientCapabilities = TextDocumentSyncClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON TextDocumentSyncClientCapabilities)
 
 instance Aeson.ToJSON TextDocumentSyncClientCapabilities where
   toJSON (TextDocumentSyncClientCapabilities arg0 arg1 arg2 arg3) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TextDocumentSyncKind.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TextDocumentSyncKind.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.TextDocumentSyncKind where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -40,6 +42,7 @@ data TextDocumentSyncKind =
   deriving anyclass (NFData, Hashable)
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum TextDocumentSyncKind Language.LSP.Protocol.Types.Common.UInt)
+  deriving Pretty via (ViaJSON TextDocumentSyncKind)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum TextDocumentSyncKind where
   knownValues = Data.Set.fromList [TextDocumentSyncKind_None

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TextDocumentSyncOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TextDocumentSyncOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.TextDocumentSyncOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -47,6 +49,7 @@ data TextDocumentSyncOptions = TextDocumentSyncOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON TextDocumentSyncOptions)
 
 instance Aeson.ToJSON TextDocumentSyncOptions where
   toJSON (TextDocumentSyncOptions arg0 arg1 arg2 arg3 arg4) = Aeson.object $ concat $  ["openClose" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TextEdit.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TextEdit.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.TextEdit where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -32,6 +34,7 @@ data TextEdit = TextEdit
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON TextEdit)
 
 instance Aeson.ToJSON TextEdit where
   toJSON (TextEdit arg0 arg1) = Aeson.object $ concat $  [["range" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TokenFormat.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TokenFormat.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.TokenFormat where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -28,6 +30,7 @@ data TokenFormat =
   deriving anyclass (NFData, Hashable)
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum TokenFormat Data.Text.Text)
+  deriving Pretty via (ViaJSON TokenFormat)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum TokenFormat where
   knownValues = Data.Set.fromList [TokenFormat_Relative]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TraceValues.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TraceValues.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.TraceValues where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -36,6 +38,7 @@ data TraceValues =
   deriving anyclass (NFData, Hashable)
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum TraceValues Data.Text.Text)
+  deriving Pretty via (ViaJSON TraceValues)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum TraceValues where
   knownValues = Data.Set.fromList [TraceValues_Off

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TypeDefinitionClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TypeDefinitionClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.TypeDefinitionClientCapabilities whe
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -32,6 +34,7 @@ data TypeDefinitionClientCapabilities = TypeDefinitionClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON TypeDefinitionClientCapabilities)
 
 instance Aeson.ToJSON TypeDefinitionClientCapabilities where
   toJSON (TypeDefinitionClientCapabilities arg0 arg1) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TypeDefinitionOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TypeDefinitionOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.TypeDefinitionOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -24,6 +26,7 @@ data TypeDefinitionOptions = TypeDefinitionOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON TypeDefinitionOptions)
 
 instance Aeson.ToJSON TypeDefinitionOptions where
   toJSON (TypeDefinitionOptions arg0) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TypeDefinitionParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TypeDefinitionParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.TypeDefinitionParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -40,6 +42,7 @@ data TypeDefinitionParams = TypeDefinitionParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON TypeDefinitionParams)
 
 instance Aeson.ToJSON TypeDefinitionParams where
   toJSON (TypeDefinitionParams arg0 arg1 arg2 arg3) = Aeson.object $ concat $  [["textDocument" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TypeDefinitionRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TypeDefinitionRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.TypeDefinitionRegistrationOptions wh
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -36,6 +38,7 @@ data TypeDefinitionRegistrationOptions = TypeDefinitionRegistrationOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON TypeDefinitionRegistrationOptions)
 
 instance Aeson.ToJSON TypeDefinitionRegistrationOptions where
   toJSON (TypeDefinitionRegistrationOptions arg0 arg1 arg2) = Aeson.object $ concat $  [["documentSelector" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TypeHierarchyClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TypeHierarchyClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.TypeHierarchyClientCapabilities wher
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -26,6 +28,7 @@ data TypeHierarchyClientCapabilities = TypeHierarchyClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON TypeHierarchyClientCapabilities)
 
 instance Aeson.ToJSON TypeHierarchyClientCapabilities where
   toJSON (TypeHierarchyClientCapabilities arg0) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TypeHierarchyItem.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TypeHierarchyItem.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.TypeHierarchyItem where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
@@ -64,6 +66,7 @@ data TypeHierarchyItem = TypeHierarchyItem
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON TypeHierarchyItem)
 
 instance Aeson.ToJSON TypeHierarchyItem where
   toJSON (TypeHierarchyItem arg0 arg1 arg2 arg3 arg4 arg5 arg6 arg7) = Aeson.object $ concat $  [["name" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TypeHierarchyOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TypeHierarchyOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.TypeHierarchyOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -26,6 +28,7 @@ data TypeHierarchyOptions = TypeHierarchyOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON TypeHierarchyOptions)
 
 instance Aeson.ToJSON TypeHierarchyOptions where
   toJSON (TypeHierarchyOptions arg0) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TypeHierarchyPrepareParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TypeHierarchyPrepareParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.TypeHierarchyPrepareParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -37,6 +39,7 @@ data TypeHierarchyPrepareParams = TypeHierarchyPrepareParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON TypeHierarchyPrepareParams)
 
 instance Aeson.ToJSON TypeHierarchyPrepareParams where
   toJSON (TypeHierarchyPrepareParams arg0 arg1 arg2) = Aeson.object $ concat $  [["textDocument" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TypeHierarchyRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TypeHierarchyRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.TypeHierarchyRegistrationOptions whe
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -38,6 +40,7 @@ data TypeHierarchyRegistrationOptions = TypeHierarchyRegistrationOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON TypeHierarchyRegistrationOptions)
 
 instance Aeson.ToJSON TypeHierarchyRegistrationOptions where
   toJSON (TypeHierarchyRegistrationOptions arg0 arg1 arg2) = Aeson.object $ concat $  [["documentSelector" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TypeHierarchySubtypesParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TypeHierarchySubtypesParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.TypeHierarchySubtypesParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -37,6 +39,7 @@ data TypeHierarchySubtypesParams = TypeHierarchySubtypesParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON TypeHierarchySubtypesParams)
 
 instance Aeson.ToJSON TypeHierarchySubtypesParams where
   toJSON (TypeHierarchySubtypesParams arg0 arg1 arg2) = Aeson.object $ concat $  ["workDoneToken" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TypeHierarchySupertypesParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/TypeHierarchySupertypesParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.TypeHierarchySupertypesParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -37,6 +39,7 @@ data TypeHierarchySupertypesParams = TypeHierarchySupertypesParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON TypeHierarchySupertypesParams)
 
 instance Aeson.ToJSON TypeHierarchySupertypesParams where
   toJSON (TypeHierarchySupertypesParams arg0 arg1 arg2) = Aeson.object $ concat $  ["workDoneToken" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/UInitializeParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/UInitializeParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.UInitializeParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson
 import qualified Data.Aeson as Aeson
 import qualified Data.Row as Row
@@ -83,6 +85,7 @@ data UInitializeParams = UInitializeParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON UInitializeParams)
 
 instance Aeson.ToJSON UInitializeParams where
   toJSON (UInitializeParams arg0 arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8) = Aeson.object $ concat $  ["workDoneToken" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/UnchangedDocumentDiagnosticReport.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/UnchangedDocumentDiagnosticReport.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.UnchangedDocumentDiagnosticReport wh
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -37,6 +39,7 @@ data UnchangedDocumentDiagnosticReport = UnchangedDocumentDiagnosticReport
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON UnchangedDocumentDiagnosticReport)
 
 instance Aeson.ToJSON UnchangedDocumentDiagnosticReport where
   toJSON (UnchangedDocumentDiagnosticReport arg0 arg1) = Aeson.object $ concat $  [["kind" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/UniquenessLevel.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/UniquenessLevel.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.UniquenessLevel where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -46,6 +48,7 @@ data UniquenessLevel =
   deriving anyclass (NFData, Hashable)
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum UniquenessLevel Data.Text.Text)
+  deriving Pretty via (ViaJSON UniquenessLevel)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum UniquenessLevel where
   knownValues = Data.Set.fromList [UniquenessLevel_Document

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/Unregistration.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/Unregistration.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.Unregistration where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -30,6 +32,7 @@ data Unregistration = Unregistration
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON Unregistration)
 
 instance Aeson.ToJSON Unregistration where
   toJSON (Unregistration arg0 arg1) = Aeson.object $ concat $  [["id" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/UnregistrationParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/UnregistrationParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.UnregistrationParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -25,6 +27,7 @@ data UnregistrationParams = UnregistrationParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON UnregistrationParams)
 
 instance Aeson.ToJSON UnregistrationParams where
   toJSON (UnregistrationParams arg0) = Aeson.object $ concat $  [["unregisterations" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/VersionedNotebookDocumentIdentifier.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/VersionedNotebookDocumentIdentifier.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.VersionedNotebookDocumentIdentifier 
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -31,6 +33,7 @@ data VersionedNotebookDocumentIdentifier = VersionedNotebookDocumentIdentifier
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON VersionedNotebookDocumentIdentifier)
 
 instance Aeson.ToJSON VersionedNotebookDocumentIdentifier where
   toJSON (VersionedNotebookDocumentIdentifier arg0 arg1) = Aeson.object $ concat $  [["version" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/VersionedTextDocumentIdentifier.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/VersionedTextDocumentIdentifier.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.VersionedTextDocumentIdentifier wher
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -29,6 +31,7 @@ data VersionedTextDocumentIdentifier = VersionedTextDocumentIdentifier
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON VersionedTextDocumentIdentifier)
 
 instance Aeson.ToJSON VersionedTextDocumentIdentifier where
   toJSON (VersionedTextDocumentIdentifier arg0 arg1) = Aeson.object $ concat $  [["uri" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WatchKind.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WatchKind.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.WatchKind where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -37,6 +39,7 @@ data WatchKind =
   deriving anyclass (NFData, Hashable)
   deriving ( Aeson.ToJSON
   , Aeson.FromJSON ) via (Language.LSP.Protocol.Types.LspEnum.AsLspEnum WatchKind Language.LSP.Protocol.Types.Common.UInt)
+  deriving Pretty via (ViaJSON WatchKind)
 
 instance Language.LSP.Protocol.Types.LspEnum.LspEnum WatchKind where
   knownValues = Data.Set.fromList [WatchKind_Create

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WillSaveTextDocumentParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WillSaveTextDocumentParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.WillSaveTextDocumentParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -30,6 +32,7 @@ data WillSaveTextDocumentParams = WillSaveTextDocumentParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON WillSaveTextDocumentParams)
 
 instance Aeson.ToJSON WillSaveTextDocumentParams where
   toJSON (WillSaveTextDocumentParams arg0 arg1) = Aeson.object $ concat $  [["textDocument" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WindowClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WindowClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.WindowClientCapabilities where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -46,6 +48,7 @@ data WindowClientCapabilities = WindowClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON WindowClientCapabilities)
 
 instance Aeson.ToJSON WindowClientCapabilities where
   toJSON (WindowClientCapabilities arg0 arg1 arg2) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkDoneProgressBegin.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkDoneProgressBegin.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.WorkDoneProgressBegin where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -56,6 +58,7 @@ data WorkDoneProgressBegin = WorkDoneProgressBegin
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON WorkDoneProgressBegin)
 
 instance Aeson.ToJSON WorkDoneProgressBegin where
   toJSON (WorkDoneProgressBegin arg0 arg1 arg2 arg3 arg4) = Aeson.object $ concat $  [["kind" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkDoneProgressCancelParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkDoneProgressCancelParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.WorkDoneProgressCancelParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -25,6 +27,7 @@ data WorkDoneProgressCancelParams = WorkDoneProgressCancelParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON WorkDoneProgressCancelParams)
 
 instance Aeson.ToJSON WorkDoneProgressCancelParams where
   toJSON (WorkDoneProgressCancelParams arg0) = Aeson.object $ concat $  [["token" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkDoneProgressCreateParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkDoneProgressCreateParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.WorkDoneProgressCreateParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -25,6 +27,7 @@ data WorkDoneProgressCreateParams = WorkDoneProgressCreateParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON WorkDoneProgressCreateParams)
 
 instance Aeson.ToJSON WorkDoneProgressCreateParams where
   toJSON (WorkDoneProgressCreateParams arg0) = Aeson.object $ concat $  [["token" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkDoneProgressEnd.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkDoneProgressEnd.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.WorkDoneProgressEnd where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -31,6 +33,7 @@ data WorkDoneProgressEnd = WorkDoneProgressEnd
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON WorkDoneProgressEnd)
 
 instance Aeson.ToJSON WorkDoneProgressEnd where
   toJSON (WorkDoneProgressEnd arg0 arg1) = Aeson.object $ concat $  [["kind" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkDoneProgressOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkDoneProgressOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.WorkDoneProgressOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -24,6 +26,7 @@ data WorkDoneProgressOptions = WorkDoneProgressOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON WorkDoneProgressOptions)
 
 instance Aeson.ToJSON WorkDoneProgressOptions where
   toJSON (WorkDoneProgressOptions arg0) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkDoneProgressParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkDoneProgressParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.WorkDoneProgressParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -25,6 +27,7 @@ data WorkDoneProgressParams = WorkDoneProgressParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON WorkDoneProgressParams)
 
 instance Aeson.ToJSON WorkDoneProgressParams where
   toJSON (WorkDoneProgressParams arg0) = Aeson.object $ concat $  ["workDoneToken" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkDoneProgressReport.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkDoneProgressReport.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.WorkDoneProgressReport where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -50,6 +52,7 @@ data WorkDoneProgressReport = WorkDoneProgressReport
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON WorkDoneProgressReport)
 
 instance Aeson.ToJSON WorkDoneProgressReport where
   toJSON (WorkDoneProgressReport arg0 arg1 arg2 arg3) = Aeson.object $ concat $  [["kind" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.WorkspaceClientCapabilities where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -110,6 +112,7 @@ data WorkspaceClientCapabilities = WorkspaceClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON WorkspaceClientCapabilities)
 
 instance Aeson.ToJSON WorkspaceClientCapabilities where
   toJSON (WorkspaceClientCapabilities arg0 arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13) = Aeson.object $ concat $  ["applyEdit" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceDiagnosticParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceDiagnosticParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.WorkspaceDiagnosticParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -43,6 +45,7 @@ data WorkspaceDiagnosticParams = WorkspaceDiagnosticParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON WorkspaceDiagnosticParams)
 
 instance Aeson.ToJSON WorkspaceDiagnosticParams where
   toJSON (WorkspaceDiagnosticParams arg0 arg1 arg2 arg3) = Aeson.object $ concat $  ["workDoneToken" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceDiagnosticReport.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceDiagnosticReport.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.WorkspaceDiagnosticReport where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -27,6 +29,7 @@ data WorkspaceDiagnosticReport = WorkspaceDiagnosticReport
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON WorkspaceDiagnosticReport)
 
 instance Aeson.ToJSON WorkspaceDiagnosticReport where
   toJSON (WorkspaceDiagnosticReport arg0) = Aeson.object $ concat $  [["items" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceDiagnosticReportPartialResult.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceDiagnosticReportPartialResult.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.WorkspaceDiagnosticReportPartialResu
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -27,6 +29,7 @@ data WorkspaceDiagnosticReportPartialResult = WorkspaceDiagnosticReportPartialRe
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON WorkspaceDiagnosticReportPartialResult)
 
 instance Aeson.ToJSON WorkspaceDiagnosticReportPartialResult where
   toJSON (WorkspaceDiagnosticReportPartialResult arg0) = Aeson.object $ concat $  [["items" Aeson..= arg0]]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceDocumentDiagnosticReport.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceDocumentDiagnosticReport.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.WorkspaceDocumentDiagnosticReport wh
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -24,3 +26,4 @@ newtype WorkspaceDocumentDiagnosticReport = WorkspaceDocumentDiagnosticReport (L
   deriving newtype (Aeson.ToJSON, Aeson.FromJSON)
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON WorkspaceDocumentDiagnosticReport)

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceEdit.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceEdit.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.WorkspaceEdit where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Map
 import qualified Data.Row.Aeson as Aeson
@@ -66,6 +68,7 @@ data WorkspaceEdit = WorkspaceEdit
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON WorkspaceEdit)
 
 instance Aeson.ToJSON WorkspaceEdit where
   toJSON (WorkspaceEdit arg0 arg1 arg2) = Aeson.object $ concat $  ["changes" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceEditClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceEditClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.WorkspaceEditClientCapabilities wher
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row as Row
 import qualified Data.Row.Aeson as Aeson
@@ -58,6 +60,7 @@ data WorkspaceEditClientCapabilities = WorkspaceEditClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON WorkspaceEditClientCapabilities)
 
 instance Aeson.ToJSON WorkspaceEditClientCapabilities where
   toJSON (WorkspaceEditClientCapabilities arg0 arg1 arg2 arg3 arg4) = Aeson.object $ concat $  ["documentChanges" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceFolder.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceFolder.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.WorkspaceFolder where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -31,6 +33,7 @@ data WorkspaceFolder = WorkspaceFolder
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON WorkspaceFolder)
 
 instance Aeson.ToJSON WorkspaceFolder where
   toJSON (WorkspaceFolder arg0 arg1) = Aeson.object $ concat $  [["uri" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceFoldersChangeEvent.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceFoldersChangeEvent.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.WorkspaceFoldersChangeEvent where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -29,6 +31,7 @@ data WorkspaceFoldersChangeEvent = WorkspaceFoldersChangeEvent
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON WorkspaceFoldersChangeEvent)
 
 instance Aeson.ToJSON WorkspaceFoldersChangeEvent where
   toJSON (WorkspaceFoldersChangeEvent arg0 arg1) = Aeson.object $ concat $  [["added" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceFoldersInitializeParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceFoldersInitializeParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.WorkspaceFoldersInitializeParams whe
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -31,6 +33,7 @@ data WorkspaceFoldersInitializeParams = WorkspaceFoldersInitializeParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON WorkspaceFoldersInitializeParams)
 
 instance Aeson.ToJSON WorkspaceFoldersInitializeParams where
   toJSON (WorkspaceFoldersInitializeParams arg0) = Aeson.object $ concat $  ["workspaceFolders" Language.LSP.Protocol.Types.Common..=? arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceFoldersServerCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceFoldersServerCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.WorkspaceFoldersServerCapabilities w
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -35,6 +37,7 @@ data WorkspaceFoldersServerCapabilities = WorkspaceFoldersServerCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON WorkspaceFoldersServerCapabilities)
 
 instance Aeson.ToJSON WorkspaceFoldersServerCapabilities where
   toJSON (WorkspaceFoldersServerCapabilities arg0 arg1) = Aeson.object $ concat $  ["supported" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceFullDocumentDiagnosticReport.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceFullDocumentDiagnosticReport.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.WorkspaceFullDocumentDiagnosticRepor
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -49,6 +51,7 @@ data WorkspaceFullDocumentDiagnosticReport = WorkspaceFullDocumentDiagnosticRepo
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON WorkspaceFullDocumentDiagnosticReport)
 
 instance Aeson.ToJSON WorkspaceFullDocumentDiagnosticReport where
   toJSON (WorkspaceFullDocumentDiagnosticReport arg0 arg1 arg2 arg3 arg4) = Aeson.object $ concat $  [["kind" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceSymbol.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceSymbol.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.WorkspaceSymbol where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson
 import qualified Data.Aeson as Aeson
 import qualified Data.Row as Row
@@ -65,6 +67,7 @@ data WorkspaceSymbol = WorkspaceSymbol
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON WorkspaceSymbol)
 
 instance Aeson.ToJSON WorkspaceSymbol where
   toJSON (WorkspaceSymbol arg0 arg1 arg2 arg3 arg4 arg5) = Aeson.object $ concat $  [["name" Aeson..= arg0]

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceSymbolClientCapabilities.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceSymbolClientCapabilities.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.WorkspaceSymbolClientCapabilities wh
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row as Row
 import qualified Data.Row.Aeson as Aeson
@@ -47,6 +49,7 @@ data WorkspaceSymbolClientCapabilities = WorkspaceSymbolClientCapabilities
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON WorkspaceSymbolClientCapabilities)
 
 instance Aeson.ToJSON WorkspaceSymbolClientCapabilities where
   toJSON (WorkspaceSymbolClientCapabilities arg0 arg1 arg2 arg3) = Aeson.object $ concat $  ["dynamicRegistration" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceSymbolOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceSymbolOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.WorkspaceSymbolOptions where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -31,6 +33,7 @@ data WorkspaceSymbolOptions = WorkspaceSymbolOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON WorkspaceSymbolOptions)
 
 instance Aeson.ToJSON WorkspaceSymbolOptions where
   toJSON (WorkspaceSymbolOptions arg0 arg1) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceSymbolParams.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceSymbolParams.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.WorkspaceSymbolParams where
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -36,6 +38,7 @@ data WorkspaceSymbolParams = WorkspaceSymbolParams
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON WorkspaceSymbolParams)
 
 instance Aeson.ToJSON WorkspaceSymbolParams where
   toJSON (WorkspaceSymbolParams arg0 arg1 arg2) = Aeson.object $ concat $  ["workDoneToken" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceSymbolRegistrationOptions.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceSymbolRegistrationOptions.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.WorkspaceSymbolRegistrationOptions w
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -31,6 +33,7 @@ data WorkspaceSymbolRegistrationOptions = WorkspaceSymbolRegistrationOptions
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON WorkspaceSymbolRegistrationOptions)
 
 instance Aeson.ToJSON WorkspaceSymbolRegistrationOptions where
   toJSON (WorkspaceSymbolRegistrationOptions arg0 arg1) = Aeson.object $ concat $  ["workDoneProgress" Language.LSP.Protocol.Types.Common..=? arg0

--- a/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceUnchangedDocumentDiagnosticReport.hs
+++ b/lsp-types/generated/Language/LSP/Protocol/Internal/Types/WorkspaceUnchangedDocumentDiagnosticReport.hs
@@ -8,6 +8,8 @@ module Language.LSP.Protocol.Internal.Types.WorkspaceUnchangedDocumentDiagnostic
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
+import Language.LSP.Protocol.Utils.Misc
+import Prettyprinter
 import qualified Data.Aeson as Aeson
 import qualified Data.Row.Aeson as Aeson
 import qualified Data.Row.Hashable as Hashable
@@ -46,6 +48,7 @@ data WorkspaceUnchangedDocumentDiagnosticReport = WorkspaceUnchangedDocumentDiag
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON WorkspaceUnchangedDocumentDiagnosticReport)
 
 instance Aeson.ToJSON WorkspaceUnchangedDocumentDiagnosticReport where
   toJSON (WorkspaceUnchangedDocumentDiagnosticReport arg0 arg1 arg2 arg3) = Aeson.object $ concat $  [["kind" Aeson..= arg0]

--- a/lsp-types/lsp-types.cabal
+++ b/lsp-types/lsp-types.cabal
@@ -78,9 +78,12 @@ library
     , dlist
     , exceptions
     , hashable          >=1.3.4.0
+    , indexed-traversable
     , lens              >=4.15.2
+    , lens-aeson
     , mod
     , mtl               <2.4
+    , prettyprinter     
     , network-uri       >=2.6
     , row-types
     , safe

--- a/lsp-types/src/Language/LSP/Protocol/Message/LspId.hs
+++ b/lsp-types/src/Language/LSP/Protocol/Message/LspId.hs
@@ -6,10 +6,12 @@ import           Data.Hashable
 import           Data.IxMap
 import           Data.Text                          (Text)
 import           GHC.Generics
+import           Prettyprinter
 
 import           Language.LSP.Protocol.Types.Common
 import           Language.LSP.Protocol.Internal.Method
 import           Language.LSP.Protocol.Message.Meta
+import           Language.LSP.Protocol.Utils.Misc
 
 -- | Id used for a request, Can be either a String or an Int
 data LspId (m :: Method f Request) = IdInt !Int32 | IdString !Text
@@ -23,6 +25,8 @@ instance A.FromJSON (LspId m) where
   parseJSON v@(A.Number _) = IdInt <$> A.parseJSON v
   parseJSON  (A.String  s) = return (IdString s)
   parseJSON _              = fail "LspId"
+
+deriving via ViaJSON (LspId m) instance Pretty (LspId m)
 
 instance IxOrd LspId where
   type Base LspId = SomeLspId

--- a/lsp-types/src/Language/LSP/Protocol/Message/Method.hs
+++ b/lsp-types/src/Language/LSP/Protocol/Message/Method.hs
@@ -24,6 +24,7 @@ import           GHC.TypeLits                       (KnownSymbol, sameSymbol,
 import           Language.LSP.Protocol.Internal.Method
 import           Language.LSP.Protocol.Message.Meta
 import           Language.LSP.Protocol.Utils.Misc
+import           Prettyprinter
 import           Unsafe.Coerce
 
 ---------------
@@ -48,6 +49,8 @@ instance FromJSON SomeMethod where
   parseJSON v = do
     s <- parseJSON v
     pure $ methodStringToSomeMethod s
+
+deriving via ViaJSON SomeMethod instance Pretty SomeMethod
 
 ---------------
 -- SMethod
@@ -104,6 +107,8 @@ instance KnownSymbol s => FromJSON (SMethod ('Method_CustomMethod s :: Method f 
 -- instance FromJSON (SMethod Method_X)
 makeSingletonFromJSON 'SomeMethod ''SMethod ['SMethod_CustomMethod]
 
+deriving via ViaJSON (SMethod m) instance Pretty (SMethod m)
+
 ---------------
 -- Extras
 ---------------
@@ -142,6 +147,8 @@ instance FromJSON SomeClientMethod where
 instance ToJSON SomeClientMethod where
   toJSON (SomeClientMethod sm) = toJSON $ someMethodToMethodString $ SomeMethod sm
 
+deriving via ViaJSON SomeClientMethod instance Pretty SomeClientMethod
+
 instance FromJSON SomeServerMethod where
   parseJSON v = do
     (SomeMethod sm) <- parseJSON v
@@ -151,6 +158,8 @@ instance FromJSON SomeServerMethod where
 
 instance ToJSON SomeServerMethod where
   toJSON (SomeServerMethod sm) = toJSON $ someMethodToMethodString $ SomeMethod sm
+
+deriving via ViaJSON SomeServerMethod instance Pretty SomeServerMethod
 
 {- Note [Parsing methods that go both ways]
 

--- a/lsp-types/src/Language/LSP/Protocol/Message/Registration.hs
+++ b/lsp-types/src/Language/LSP/Protocol/Message/Registration.hs
@@ -20,6 +20,7 @@ import           Data.Aeson
 import           Data.Text                         (Text)
 import qualified Data.Text                         as T
 import           GHC.Generics
+import           Prettyprinter
 
 -- | Typed registration type, with correct options.
 data TRegistration (m :: Method ClientToServer t) =
@@ -51,6 +52,8 @@ makeRegHelper ''RegistrationOptions
 instance ToJSON (TRegistration m) where
   toJSON x@(TRegistration _ m _) = regHelper m (genericToJSON lspOptions x)
 
+deriving via ViaJSON (TRegistration m) instance Pretty (TRegistration m)
+
 data SomeRegistration = forall t (m :: Method ClientToServer t). SomeRegistration (TRegistration m)
 
 instance ToJSON SomeRegistration where
@@ -64,6 +67,8 @@ instance FromJSON SomeRegistration where
 
 instance Show SomeRegistration where
   show (SomeRegistration r@(TRegistration _ m _)) = regHelper m (show r)
+
+deriving via ViaJSON SomeRegistration instance Pretty SomeRegistration
 
 toUntypedRegistration :: TRegistration m -> Registration
 toUntypedRegistration (TRegistration i meth opts) = Registration i (T.pack $ someMethodToMethodString $ SomeMethod meth) (Just $ regHelper meth (toJSON opts))
@@ -93,6 +98,8 @@ deriving stock instance Show (TUnregistration m)
 instance ToJSON (TUnregistration m) where
   toJSON x@(TUnregistration _ m) = regHelper m (genericToJSON lspOptions x)
 
+deriving via ViaJSON (TUnregistration m) instance Pretty (TUnregistration m)
+
 data SomeUnregistration = forall t (m :: Method ClientToServer t). SomeUnregistration (TUnregistration m)
 
 instance ToJSON SomeUnregistration where
@@ -103,6 +110,8 @@ instance FromJSON SomeUnregistration where
     SomeClientMethod m <- o .: "method"
     r <- TUnregistration <$> o .: "id" <*> pure m
     pure (SomeUnregistration r)
+
+deriving via ViaJSON SomeUnregistration instance Pretty SomeUnregistration
 
 toUntypedUnregistration :: TUnregistration m -> Unregistration
 toUntypedUnregistration (TUnregistration i meth) = Unregistration i (T.pack $ someMethodToMethodString $ SomeMethod meth)

--- a/lsp-types/src/Language/LSP/Protocol/Types/Common.hs
+++ b/lsp-types/src/Language/LSP/Protocol/Types/Common.hs
@@ -37,9 +37,11 @@ import           Data.Set            as Set
 import           Data.String         (fromString)
 import           Data.Int            (Int32)
 import           Data.Mod.Word
+import           Language.LSP.Protocol.Utils.Misc
 import           GHC.Generics        hiding (UInt)
 import           GHC.TypeNats        hiding (Mod)
 import           Text.Read           (Read (readPrec))
+import           Prettyprinter
 
 -- | The "uinteger" type in the LSP spec.
 --
@@ -56,6 +58,9 @@ instance Show UInt where
 
 instance Read UInt where
   readPrec = fromInteger <$> readPrec
+
+instance Pretty UInt where
+  pretty = viaShow
 
 instance Real UInt where
   toRational (UInt u) = toRational $ unMod u
@@ -78,6 +83,7 @@ data a |? b = InL a
             | InR b
   deriving stock (Read, Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON (a |? b))
 infixr |?
 
 -- | Prism for the left-hand side of an '(|?)'.
@@ -139,6 +145,7 @@ instance (FromJSON a, ToJSON a, FromJSON b, ToJSON b) => FromJSON (a |? b) where
 data Null = Null
   deriving stock (Eq, Ord, Show, Generic)
   deriving anyclass (NFData, Hashable)
+  deriving Pretty via (ViaJSON Null)
 
 instance ToJSON Null where
   toJSON Null = J.Null

--- a/lsp-types/src/Language/LSP/Protocol/Types/Singletons.hs
+++ b/lsp-types/src/Language/LSP/Protocol/Types/Singletons.hs
@@ -7,6 +7,7 @@ import qualified Data.Text    as T
 import           Control.DeepSeq
 import           GHC.TypeLits (KnownNat, KnownSymbol, Nat, Symbol, natVal,
                                symbolVal)
+import           Prettyprinter
 
 -- | A type whose only inhabitant is a single, statically-known string.
 --
@@ -17,6 +18,8 @@ data AString (s :: Symbol) where
 
 instance Show (AString s) where
   show AString = symbolVal (Proxy @s)
+instance Pretty (AString s) where
+  pretty = viaShow
 instance Eq (AString s) where
   _ == _ = True
 instance Ord (AString s) where
@@ -45,6 +48,8 @@ data AnInteger (n :: Nat) where
 
 instance Show (AnInteger n) where
   show AnInteger = show $ natVal (Proxy @n)
+instance Pretty (AnInteger n) where
+  pretty = viaShow
 instance Eq (AnInteger n) where
   _ == _ = True
 instance Ord (AnInteger n) where

--- a/lsp-types/src/Language/LSP/Protocol/Types/Uri.hs
+++ b/lsp-types/src/Language/LSP/Protocol/Types/Uri.hs
@@ -40,11 +40,12 @@ import qualified System.FilePath         as FP
 import qualified System.FilePath.Posix   as FPP
 import qualified System.FilePath.Windows as FPW
 import qualified System.Info
+import           Prettyprinter
 
 -- | The @Uri@ type in the LSP specification.
 newtype Uri = Uri { getUri :: Text }
   deriving stock (Eq,Ord,Read,Show,Generic)
-  deriving newtype (A.FromJSON,A.ToJSON,Hashable,A.ToJSONKey,A.FromJSONKey)
+  deriving newtype (A.FromJSON,A.ToJSON,Hashable,A.ToJSONKey,A.FromJSONKey, Pretty)
 
 instance NFData Uri
 
@@ -66,6 +67,9 @@ instance Ord NormalizedUri where
 instance Hashable NormalizedUri where
   hash (NormalizedUri h _) = h
   hashWithSalt salt (NormalizedUri h _) = hashWithSalt salt h
+
+instance Pretty NormalizedUri where
+  pretty (NormalizedUri _ t) = pretty t
 
 instance NFData NormalizedUri
 

--- a/lsp/src/Language/LSP/Server/Core.hs
+++ b/lsp/src/Language/LSP/Server/Core.hs
@@ -61,6 +61,7 @@ import           Language.LSP.Protocol.Types
 import qualified Language.LSP.Protocol.Types            as L
 import           Language.LSP.Protocol.Utils.SMethodMap (SMethodMap)
 import qualified Language.LSP.Protocol.Utils.SMethodMap as SMethodMap
+import           Language.LSP.Protocol.Utils.Misc (prettyJSON)
 import           Language.LSP.VFS
 import           Prettyprinter
 import           System.Random                          hiding (next)
@@ -82,17 +83,17 @@ data LspCoreLog =
   deriving Show
 
 instance Pretty LspCoreLog where
-  pretty (NewConfig config) = "LSP: set new config:" <+> viaShow config
+  pretty (NewConfig config) = "LSP: set new config:" <+> prettyJSON config
   pretty (ConfigurationNotSupported) = "LSP: not requesting configuration since the client does not support workspace/configuration"
   pretty (ConfigurationParseError settings err) =
     vsep [
       "LSP: configuration parse error:"
       , pretty err
       , "when parsing"
-      , viaShow settings
+      , prettyJSON settings
       ]
-  pretty (BadConfigurationResponse err) = "LSP: error when requesting configuration: " <+> viaShow err
-  pretty (WrongConfigSections sections) = "LSP: expected only one configuration section, got: " <+> viaShow sections
+  pretty (BadConfigurationResponse err) = "LSP: error when requesting configuration: " <+> pretty err
+  pretty (WrongConfigSections sections) = "LSP: expected only one configuration section, got: " <+> (prettyJSON $ J.toJSON sections)
 
 newtype LspT config m a = LspT { unLspT :: ReaderT (LanguageContextEnv config) m a }
   deriving (Functor, Applicative, Monad, MonadCatch, MonadIO, MonadMask, MonadThrow, MonadTrans, MonadUnliftIO, MonadFix)

--- a/lsp/src/Language/LSP/Server/Processing.hs
+++ b/lsp/src/Language/LSP/Server/Processing.hs
@@ -84,8 +84,8 @@ instance Pretty LspProcessingLog where
       , "when processing"
       , pretty (TL.decodeUtf8 bs)
       ]
-  pretty (MissingHandler _ m) = "LSP: no handler for:" <+> viaShow m
-  pretty (ProgressCancel tid) = "LSP: cancelling action for token:" <+> viaShow tid
+  pretty (MissingHandler _ m) = "LSP: no handler for:" <+> pretty m
+  pretty (ProgressCancel tid) = "LSP: cancelling action for token:" <+> pretty tid
   pretty Exiting = "LSP: Got exit, exiting"
 
 processMessage :: (m ~ LspM config) => LogAction m (WithSeverity LspProcessingLog) -> BSL.ByteString -> m ()

--- a/lsp/src/Language/LSP/VFS.hs
+++ b/lsp/src/Language/LSP/VFS.hs
@@ -126,13 +126,13 @@ data VfsLog =
 instance Pretty VfsLog where
   pretty (SplitInsideCodePoint pos r) =
     "VFS: asked to make change inside code point. Position" <+> viaShow pos <+> "in" <+> viaShow r
-  pretty (URINotFound uri) = "VFS: don't know about URI" <+> viaShow uri
-  pretty (Opening uri) = "VFS: opening" <+> viaShow uri
-  pretty (Closing uri) = "VFS: closing" <+> viaShow uri
-  pretty (PersistingFile uri fp) = "VFS: Writing virtual file for" <+> viaShow uri <+> "to" <+> viaShow fp
+  pretty (URINotFound uri) = "VFS: don't know about URI" <+> pretty uri
+  pretty (Opening uri) = "VFS: opening" <+> pretty uri
+  pretty (Closing uri) = "VFS: closing" <+> pretty uri
+  pretty (PersistingFile uri fp) = "VFS: Writing virtual file for" <+> pretty uri <+> "to" <+> viaShow fp
   pretty (CantRecursiveDelete uri) =
-    "VFS: can't recursively delete" <+> viaShow uri <+> "because we don't track directory status"
-  pretty (DeleteNonExistent uri) = "VFS: asked to delete non-existent file" <+> viaShow uri
+    "VFS: can't recursively delete" <+> pretty uri <+> "because we don't track directory status"
+  pretty (DeleteNonExistent uri) = "VFS: asked to delete non-existent file" <+> pretty uri
 
 makeFieldsNoPrefix ''VirtualFile
 makeFieldsNoPrefix ''VFS


### PR DESCRIPTION
The instances just prettyprint their JSON representations, which is often what we want and is better than using `Show`!

Ultimately this means we should get much better layout when prettyprinting logs and errors that reference LSP entities when we fix downstream uses to avoid `viaShow`.