### PR TITLE
inlay-hint-support

### DIFF
--- a/lsp-types/src/Language/LSP/Protocol/Capabilities.hs
+++ b/lsp-types/src/Language/LSP/Protocol/Capabilities.hs
@@ -64,11 +64,11 @@ capsForVersion (LSPVersion maj min) = caps
       , _workspaceFolders = since 3 6 True
       , _configuration = since 3 6 True
       , _semanticTokens = since 3 16 (SemanticTokensWorkspaceClientCapabilities $ Just True)
+      , _inlayHint = since 3 17 inlayHint
       -- TODO
       , _codeLens = Nothing
       , _fileOperations = Nothing
       , _inlineValue = Nothing
-      , _inlayHint = Nothing
       , _diagnostics = Nothing
       }
 
@@ -158,12 +158,12 @@ capsForVersion (LSPVersion maj min) = caps
           , _selectionRange=since 3 5 (SelectionRangeClientCapabilities dynamicReg)
           , _callHierarchy=since 3 16 (CallHierarchyClientCapabilities dynamicReg)
           , _semanticTokens=since 3 16 semanticTokensCapabilities
+          , _inlayHint=since 3 17 inlayHintCapabilities
           -- TODO
           , _linkedEditingRange=Nothing
           , _moniker=Nothing
           , _typeHierarchy=Nothing
           , _inlineValue=Nothing
-          , _inlayHint=Nothing
           , _diagnostic=Nothing
         }
 
@@ -184,6 +184,17 @@ capsForVersion (LSPVersion maj min) = caps
         , _contextSupport=since 3 3 True
         , _completionList=since 3 17 (#itemDefaults .== Just [])
         }
+    
+    inlayHint =
+      InlayHintWorkspaceClientCapabilities{
+        _refreshSupport=since 3 17 True
+      }
+    
+    inlayHintCapabilities =
+      InlayHintClientCapabilities{
+        _dynamicRegistration=dynamicReg,
+        _resolveSupport= since 3 17 (#properties .== [])
+      }
 
     completionItemCapabilities =
       #snippetSupport .== Just True

--- a/lsp/src/Language/LSP/Server/Core.hs
+++ b/lsp/src/Language/LSP/Server/Core.hs
@@ -609,6 +609,7 @@ registerCapability method regOpts f = do
       SMethod_TextDocumentFoldingRange         -> capDyn $ clientCaps ^? L.textDocument . _Just . L.foldingRange . _Just
       SMethod_TextDocumentSelectionRange       -> capDyn $ clientCaps ^? L.textDocument . _Just . L.selectionRange . _Just
       SMethod_TextDocumentPrepareCallHierarchy -> capDyn $ clientCaps ^? L.textDocument . _Just . L.callHierarchy . _Just
+      SMethod_TextDocumentInlayHint            -> capDyn $ clientCaps ^? L.textDocument . _Just . L.inlayHint . _Just
       --SMethod_TextDocumentSemanticTokens       -> capDyn $ clientCaps ^? L.textDocument . _Just . L.semanticTokens . _Just
       _                                        -> False
 

--- a/lsp/src/Language/LSP/Server/Processing.hs
+++ b/lsp/src/Language/LSP/Server/Processing.hs
@@ -192,6 +192,7 @@ inferServerCapabilities clientCaps o h =
     { _textDocumentSync                 = sync
     , _hoverProvider                    = supportedBool SMethod_TextDocumentHover
     , _completionProvider               = completionProvider
+    , _inlayHintProvider                = inlayProvider
     , _declarationProvider              = supportedBool SMethod_TextDocumentDeclaration
     , _signatureHelpProvider            = signatureHelpProvider
     , _definitionProvider               = supportedBool SMethod_TextDocumentDefinition
@@ -228,7 +229,6 @@ inferServerCapabilities clientCaps o h =
     , _monikerProvider  = Nothing
     , _typeHierarchyProvider  = Nothing
     , _inlineValueProvider  = Nothing
-    , _inlayHintProvider  = Nothing
     , _diagnosticProvider  = Nothing
     }
   where
@@ -262,6 +262,14 @@ inferServerCapabilities clientCaps o h =
             , _completionItem=Nothing
             , _workDoneProgress=Nothing
             }
+      | otherwise = Nothing
+    
+    inlayProvider
+      | supported_b SMethod_TextDocumentInlayHint = Just $
+          InR $ InL InlayHintOptions {
+            _workDoneProgress = Nothing,
+            _resolveProvider = supported SMethod_InlayHintResolve
+          }
       | otherwise = Nothing
 
     clientSupportsCodeActionKinds = isJust $


### PR DESCRIPTION
Hi, I was playing around with this, and started working on inlay hints, but then noticed the inlay hint support was missing.

Here are the necessary changes. I only work with static handlers, so I haven't tested it with dynamic registration, but it works with the lsp I'm working with.