### PR TITLE
Remove pointless IO from VFS

### DIFF
--- a/lsp-test/src/Language/LSP/Test/Session.hs
+++ b/lsp-test/src/Language/LSP/Test/Session.hs
@@ -282,8 +282,8 @@ runSession' serverIn serverOut mServerProc serverHandler config caps rootDir exi
   mainThreadId <- myThreadId
 
   let context = SessionContext serverIn absRootDir messageChan timeoutIdVar reqMap initRsp config caps
-      initState vfs = SessionState 0 vfs mempty False Nothing mempty (lspConfig config) mempty (ignoreLogNotifications config) (ignoreConfigurationRequests config)
-      runSession' ses = initVFS $ \vfs -> runSessionMonad context (initState vfs) ses
+      initState = SessionState 0 emptyVFS mempty False Nothing mempty (lspConfig config) mempty (ignoreLogNotifications config) (ignoreConfigurationRequests config)
+      runSession' = runSessionMonad context initState
 
       errorHandler = throwTo mainThreadId :: SessionException -> IO ()
       serverListenerLauncher =
@@ -306,7 +306,7 @@ runSession' serverIn serverOut mServerProc serverHandler config caps rootDir exi
 
   (result, _) <- bracket serverListenerLauncher
                          serverAndListenerFinalizer
-                         (const $ initVFS $ \vfs -> runSessionMonad context (initState vfs) session)
+                         (const $ runSessionMonad context initState session)
   return result
 
 updateStateC :: ConduitM FromServerMessage FromServerMessage (StateT SessionState (ReaderT SessionContext IO)) ()

--- a/lsp/ChangeLog.md
+++ b/lsp/ChangeLog.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Fix inference of server capabilities for newer methods (except notebook methods).
+- VFS no longer requires IO to initialize, functions that wrote to a temporary directory
+  now take the directory as an argument.
 
 ## 2.2.0.0
 

--- a/lsp/lsp.cabal
+++ b/lsp/lsp.cabal
@@ -72,7 +72,6 @@ library
     , row-types
     , sorted-list           ^>=0.2.1
     , stm                   ^>=2.5
-    , temporary
     , text
     , text-rope
     , transformers          >=0.5.6   && <0.7

--- a/lsp/src/Language/LSP/Server/Control.hs
+++ b/lsp/src/Language/LSP/Server/Control.hs
@@ -142,8 +142,7 @@ runServerWith ioLogger logger clientIn clientOut serverDefinition = do
 
   let sendMsg msg = atomically $ writeTChan cout $ J.toJSON msg
 
-  initVFS $ \vfs -> do
-    ioLoop ioLogger logger clientIn serverDefinition vfs sendMsg
+  ioLoop ioLogger logger clientIn serverDefinition emptyVFS sendMsg
 
   return 1
 

--- a/lsp/src/Language/LSP/Server/Core.hs
+++ b/lsp/src/Language/LSP/Server/Core.hs
@@ -453,13 +453,13 @@ snapshotVirtualFiles :: LanguageContextEnv c -> STM VFS
 snapshotVirtualFiles env = vfsData <$> readTVar (resVFS $ resState env)
 {-# INLINE snapshotVirtualFiles #-}
 
-{- | Dump the current text for a given VFS file to a temporary file,
- and return the path to the file.
+{- | Dump the current text for a given VFS file to a file
+ in the given directory and return the path to the file.
 -}
-persistVirtualFile :: MonadLsp config m => LogAction m (WithSeverity VfsLog) -> NormalizedUri -> m (Maybe FilePath)
-persistVirtualFile logger uri = do
+persistVirtualFile :: MonadLsp config m => LogAction m (WithSeverity VfsLog) -> FilePath -> NormalizedUri -> m (Maybe FilePath)
+persistVirtualFile logger dir uri = do
   join $ stateState resVFS $ \vfs ->
-    case persistFileVFS logger (vfsData vfs) uri of
+    case persistFileVFS logger dir (vfsData vfs) uri of
       Nothing -> (return Nothing, vfs)
       Just (fn, write) ->
         let !revMap = case uriToFilePath (fromNormalizedUri uri) of


### PR DESCRIPTION
Setting up the VFS required IO just so it could capture a reference to a temporary directory that could be used if we wanted to write files out. This is weird and non-compositional: we can just ask the caller where they want the files, and they can make the temporary directory if they want.