### PR TITLE
Requre aeson 2

### DIFF
--- a/lsp-types/ChangeLog.md
+++ b/lsp-types/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for lsp-types
 
+## Unreleased
+
+- Require aeson 2
+
 ## 2.1.0.0
 
 - Add `dynamicRegistrationSupported` to `Capabilities`.

--- a/lsp-types/lsp-types.cabal
+++ b/lsp-types/lsp-types.cabal
@@ -69,7 +69,7 @@ library
     UndecidableInstances
 
   build-depends:
-    , aeson             >=1.2.2.0 && <2.3
+    , aeson             >=2       && <2.3
     , base              >=4.11    && <5
     , binary
     , containers
@@ -92,8 +92,6 @@ library
     , some
     , template-haskell
     , text
-    -- needed for aeson < 1
-    , unordered-containers
 
   if flag(force-ospath)
     build-depends: filepath ^>=1.4.100.0
@@ -528,7 +526,7 @@ library metamodel
     Language.LSP.MetaModel.Types
 
   build-depends:
-    , aeson             >=1.2.2.0
+    , aeson             >=2
     , base              >=4.11    && <5
     , file-embed
     , lens              >=4.15.2

--- a/lsp-types/src/Language/LSP/Protocol/Types/Common.hs
+++ b/lsp-types/src/Language/LSP/Protocol/Types/Common.hs
@@ -27,11 +27,7 @@ import Control.DeepSeq
 import Control.Lens
 import Data.Aeson hiding (Null)
 import Data.Aeson qualified as J
-#if MIN_VERSION_aeson(2,0,0)
-import qualified Data.Aeson.KeyMap   as KM
-#else
-import qualified Data.HashMap.Strict   as KM
-#endif
+import Data.Aeson.KeyMap qualified as KM
 import Data.Hashable
 import Data.Int (Int32)
 import Data.Mod.Word

--- a/lsp/lsp.cabal
+++ b/lsp/lsp.cabal
@@ -51,7 +51,7 @@ library
 
   ghc-options:        -Wall
   build-depends:
-    , aeson                 >=1.0.0.0
+    , aeson                 >=2
     , async                 >=2.0
     , attoparsec
     , base                  >=4.11    && <5


### PR DESCRIPTION
HLS used to need to build with aeson 1 for old versions of GHC, but that's no longer the case so we can finally stop maintaining compatibility with both.