### PR TITLE
Drop 9.0 from CI

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc-version: ['9.8', '9.6', '9.4', '9.2', '9.0']
+        ghc-version: ['9.8', '9.6', '9.4', '9.2']
         # Unlikely that we'll succeed on windows and fail on macos,
         # including it is just burning CI time. But windows could have
         # path or IO issues, so worth including


### PR DESCRIPTION
HLS no longer supports it.