### PR TITLE
Add bounds to all dependencies

### DIFF
--- a/lsp-test/lsp-test.cabal
+++ b/lsp-test/lsp-test.cabal
@@ -45,7 +45,7 @@ library
   build-depends:
     , aeson               >=2     && <2.3
     , aeson-pretty        ^>=0.8
-    , ansi-terminal       ^>=1.0
+    , ansi-terminal       >= 0.10 && < 1.1
     , async               ^>=2.2
     , base                >=4.10  && <5
     , bytestring          >=0.10  && <0.13

--- a/lsp-test/lsp-test.cabal
+++ b/lsp-test/lsp-test.cabal
@@ -63,7 +63,7 @@ library
     , lens-aeson          ^>=1.2
     , lsp                 ^>=2.3
     , lsp-types           ^>=2.1
-    , mtl                 ^>=2.3
+    , mtl                 >= 2.2 && < 2.4
     , parser-combinators  ^>=1.3
     , process             ^>=1.6
     , row-types           ^>=1.0

--- a/lsp-test/lsp-test.cabal
+++ b/lsp-test/lsp-test.cabal
@@ -54,7 +54,7 @@ library
     , conduit-parse       ^>=0.2
     , containers          ^>=0.6
     , data-default        ^>=0.7
-    , Diff                ^>=0.5
+    , Diff                >= 0.4 && < 0.6
     , directory           ^>=1.3
     , exceptions          ^>=0.10
     , filepath            ^>=1.4

--- a/lsp-test/lsp-test.cabal
+++ b/lsp-test/lsp-test.cabal
@@ -43,37 +43,38 @@ library
     , parser-combinators:Control.Applicative.Combinators
 
   build-depends:
-    , aeson
-    , aeson-pretty
-    , ansi-terminal
-    , async                 >=2.0
-    , base                  >=4.10  && <5
-    , bytestring
-    , co-log-core
-    , conduit
-    , conduit-parse         ^>=0.2
-    , containers            >=0.5.9
-    , data-default
-    , Diff                  >=0.3
-    , directory
-    , exceptions
-    , filepath
-    , Glob                  >=0.9   && <0.11
-    , lens
-    , lens-aeson
-    , lsp                   ^>=2.3
-    , lsp-types             ^>=2.1
-    , mtl                   <2.4
-    , parser-combinators    >=1.2
-    , process               >=1.6
-    , row-types
-    , some
-    , text
-    , time
-    , transformers
+    , aeson               >=2     && <2.3
+    , aeson-pretty        ^>=0.8
+    , ansi-terminal       ^>=1.0
+    , async               ^>=2.2
+    , base                >=4.10  && <5
+    , bytestring          >=0.10  && <0.13
+    , co-log-core         ^>=0.3
+    , conduit             ^>=1.3
+    , conduit-parse       ^>=0.2
+    , containers          ^>=0.6
+    , data-default        ^>=0.7
+    , Diff                ^>=0.5
+    , directory           ^>=1.3
+    , exceptions          ^>=0.10
+    , filepath            ^>=1.4
+    , Glob                >=0.9   && <0.11
+    , lens                >=5.1   && <5.3
+    , lens-aeson          ^>=1.2
+    , lsp                 ^>=2.3
+    , lsp-types           ^>=2.1
+    , mtl                 ^>=2.3
+    , parser-combinators  ^>=1.3
+    , process             ^>=1.6
+    , row-types           ^>=1.0
+    , some                ^>=1.0
+    , text                >=1     && <2.2
+    , time                >=1.10  && <1.13
+    , transformers        >=0.5   && <0.7
 
   if os(windows)
     build-depends: Win32
+
   else
     build-depends: unix
 
@@ -89,37 +90,36 @@ library
   ghc-options:        -W
 
 test-suite tests
-  type:             exitcode-stdio-1.0
-  hs-source-dirs:   test
-  main-is:          Test.hs
-  default-language: Haskell2010
+  type:               exitcode-stdio-1.0
+  hs-source-dirs:     test
+  main-is:            Test.hs
+  default-language:   Haskell2010
   default-extensions: ImportQualifiedPost
-  ghc-options:      -W
-  other-modules:    DummyServer
+  ghc-options:        -W
+  other-modules:      DummyServer
   build-depends:
     , aeson
-    , base          >=4.10 && <5
+    , base                >=4.10 && <5
     , containers
     , data-default
     , directory
     , filepath
     , hspec
     , lens
-    , lsp           ^>=2.3
+    , lsp                 ^>=2.3
     , lsp-test
-    , mtl           <2.4
+    , mtl                 <2.4
     , parser-combinators
     , process
     , text
     , unliftio
 
-
 test-suite func-test
-  type:             exitcode-stdio-1.0
-  hs-source-dirs:   func-test
-  default-language: Haskell2010
+  type:               exitcode-stdio-1.0
+  hs-source-dirs:     func-test
+  default-language:   Haskell2010
   default-extensions: ImportQualifiedPost
-  main-is:          FuncTest.hs
+  main-is:            FuncTest.hs
   build-depends:
     , base
     , co-log-core
@@ -131,7 +131,6 @@ test-suite func-test
     , process
     , unliftio
 
-
 test-suite example
   type:               exitcode-stdio-1.0
   hs-source-dirs:     example
@@ -142,19 +141,19 @@ test-suite example
     , base
     , lsp-test
     , parser-combinators
+
   build-tool-depends: lsp:lsp-demo-reactor-server
 
 benchmark simple-bench
-  type:             exitcode-stdio-1.0
-  hs-source-dirs:   bench
-  default-language: Haskell2010
+  type:               exitcode-stdio-1.0
+  hs-source-dirs:     bench
+  default-language:   Haskell2010
   default-extensions: ImportQualifiedPost
-  main-is:          SimpleBench.hs
-  ghc-options:      -Wall -O2 -eventlog -rtsopts
+  main-is:            SimpleBench.hs
+  ghc-options:        -Wall -O2 -eventlog -rtsopts
   build-depends:
     , base
     , extra
     , lsp
     , lsp-test
     , process
-

--- a/lsp-types/lsp-types.cabal
+++ b/lsp-types/lsp-types.cabal
@@ -78,12 +78,12 @@ library
     , deepseq                        >=1.4   && <1.6
     , Diff                           ^>=0.5
     , dlist                          ^>=1.0
-    --, exceptions                     ^>=0.10
+    , exceptions                     ^>=0.10
     , hashable                       ^>=1.4
     , indexed-traversable            ^>=0.1
     , indexed-traversable-instances  ^>=0.1
     , lens                           >=5.1   && <5.3
-    --, lens-aeson                     ^>=1.2
+    , lens-aeson                     ^>=1.2
     , mod                            ^>=0.2
     , mtl                            ^>=2.3
     , network-uri                    ^>=2.6

--- a/lsp-types/lsp-types.cabal
+++ b/lsp-types/lsp-types.cabal
@@ -85,7 +85,7 @@ library
     , lens                           >=5.1   && <5.3
     , lens-aeson                     ^>=1.2
     , mod                            ^>=0.2
-    , mtl                            ^>=2.3
+    , mtl                            >= 2.2 && < 2.4
     , network-uri                    ^>=2.6
     , prettyprinter                  ^>=1.7
     , row-types                      ^>=1.0

--- a/lsp-types/lsp-types.cabal
+++ b/lsp-types/lsp-types.cabal
@@ -76,7 +76,7 @@ library
     , containers                     ^>=0.6
     , data-default                   ^>=0.7
     , deepseq                        >=1.4   && <1.6
-    , Diff                           ^>=0.5
+    , Diff                           >= 0.4 && < 0.6
     , dlist                          ^>=1.0
     , exceptions                     ^>=0.10
     , hashable                       ^>=1.4

--- a/lsp-types/lsp-types.cabal
+++ b/lsp-types/lsp-types.cabal
@@ -18,8 +18,8 @@ category:           Development
 build-type:         Simple
 extra-source-files:
   ChangeLog.md
-  README.md
   metaModel.json
+  README.md
 
 source-repository head
   type:     git
@@ -34,6 +34,7 @@ flag force-ospath
 library
   hs-source-dirs:     src generated
   default-language:   Haskell2010
+
   -- Various things we want on by default
   -- * syntactic niceties, QOL
   -- * we always want more deriving options
@@ -69,32 +70,33 @@ library
     UndecidableInstances
 
   build-depends:
-    , aeson             >=2       && <2.3
-    , base              >=4.11    && <5
-    , binary
-    , containers
-    , data-default
-    , deepseq
-    , Diff              >=0.2
-    , dlist
-    , exceptions
-    , hashable          >=1.3.4.0
-    , indexed-traversable
-    , indexed-traversable-instances
-    , lens              >=4.15.2
-    , lens-aeson
-    , mod
-    , mtl               <2.4
-    , prettyprinter     
-    , network-uri       >=2.6
-    , row-types         >=1.0
-    , safe
-    , some
-    , template-haskell
-    , text
+    , aeson                          >=2     && <2.3
+    , base                           >=4.11  && <5
+    , binary                         ^>=0.8
+    , containers                     ^>=0.6
+    , data-default                   ^>=0.7
+    , deepseq                        >=1.4   && <1.6
+    , Diff                           ^>=0.5
+    , dlist                          ^>=1.0
+    --, exceptions                     ^>=0.10
+    , hashable                       ^>=1.4
+    , indexed-traversable            ^>=0.1
+    , indexed-traversable-instances  ^>=0.1
+    , lens                           >=5.1   && <5.3
+    --, lens-aeson                     ^>=1.2
+    , mod                            ^>=0.2
+    , mtl                            ^>=2.3
+    , network-uri                    ^>=2.6
+    , prettyprinter                  ^>=1.7
+    , row-types                      ^>=1.0
+    , safe                           ^>=0.3
+    , some                           ^>=1.0
+    , template-haskell               >=2.7   && <2.22
+    , text                           >=1     && <2.2
 
   if flag(force-ospath)
     build-depends: filepath ^>=1.4.100.0
+
   else
     build-depends: filepath
 
@@ -107,9 +109,9 @@ library
     Data.Row.Aeson
     Data.Row.Hashable
     Language.LSP.Protocol.Capabilities
+    Language.LSP.Protocol.Lens
     Language.LSP.Protocol.Message
     Language.LSP.Protocol.Types
-    Language.LSP.Protocol.Lens
     Language.LSP.Protocol.Utils.Misc
     Language.LSP.Protocol.Utils.SMethodMap
 
@@ -517,17 +519,20 @@ library
 library metamodel
   -- We don't currently re-export this from the main
   -- library, but it's here if people want it
-  visibility: public
+  visibility:         public
   hs-source-dirs:     metamodel
   default-language:   Haskell2010
-  default-extensions: StrictData ImportQualifiedPost
+  default-extensions:
+    ImportQualifiedPost
+    StrictData
+
   exposed-modules:
     Language.LSP.MetaModel
     Language.LSP.MetaModel.Types
 
   build-depends:
     , aeson             >=2
-    , base              >=4.11    && <5
+    , base              >=4.11   && <5
     , file-embed
     , lens              >=4.15.2
     , template-haskell
@@ -536,7 +541,10 @@ library metamodel
 executable generator
   hs-source-dirs:     generator
   default-language:   Haskell2010
-  default-extensions: StrictData ImportQualifiedPost
+  default-extensions:
+    ImportQualifiedPost
+    StrictData
+
   main-is:            Main.hs
   other-modules:      CodeGen
   build-depends:
@@ -569,7 +577,6 @@ test-suite lsp-types-test
     WorkspaceEditSpec
 
   ghc-options:        -threaded -rtsopts -with-rtsopts=-N -Wall
-
   build-depends:
     , aeson                 >=2.0.3.0
     , base

--- a/lsp-types/src/Language/LSP/Protocol/Message/Types.hs
+++ b/lsp-types/src/Language/LSP/Protocol/Message/Types.hs
@@ -12,7 +12,6 @@ import Language.LSP.Protocol.Message.LspId
 import Language.LSP.Protocol.Message.Meta
 import Language.LSP.Protocol.Message.Method ()
 import Language.LSP.Protocol.Types
-import Language.LSP.Protocol.Types.Common
 import Language.LSP.Protocol.Utils.Misc
 
 import Data.Aeson hiding (Null)

--- a/lsp-types/test/URIFilePathSpec.hs
+++ b/lsp-types/test/URIFilePathSpec.hs
@@ -14,6 +14,8 @@ module URIFilePathSpec where
 
 #ifdef OS_PATH
 import qualified System.OsPath           as OsPath
+import Control.Exception (throwIO)
+import Data.Maybe (fromJust)
 #endif
 
 import Control.Monad (when)

--- a/lsp-types/test/URIFilePathSpec.hs
+++ b/lsp-types/test/URIFilePathSpec.hs
@@ -16,10 +16,8 @@ module URIFilePathSpec where
 import qualified System.OsPath           as OsPath
 #endif
 
-import Control.Exception (throwIO)
 import Control.Monad (when)
 import Data.List
-import Data.Maybe (fromJust)
 import Data.Text (Text, pack)
 import Language.LSP.Protocol.Types
 

--- a/lsp/example/Reactor.hs
+++ b/lsp/example/Reactor.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeInType #-}
+{-# LANGUAGE TypeOperators #-}
 -- So we can keep using the old prettyprinter modules (which have a better
 -- compatibility range) for now.
 {-# OPTIONS_GHC -Wno-deprecations #-}

--- a/lsp/lsp.cabal
+++ b/lsp/lsp.cabal
@@ -65,7 +65,7 @@ library
     , lens                  >=5.1    && <5.3
     , lens-aeson            ^>=1.2
     , lsp-types             ^>=2.1
-    , mtl                   ^>=2.3
+    , mtl                   >= 2.2 && < 2.4
     , prettyprinter         ^>=1.7
     , random                ^>=1.2
     , row-types             ^>=1.0

--- a/lsp/lsp.cabal
+++ b/lsp/lsp.cabal
@@ -31,7 +31,6 @@ library
   default-language:   Haskell2010
   default-extensions: ImportQualifiedPost
   ghc-options:        -Wall -fprint-explicit-kinds
-
   reexported-modules:
     , Language.LSP.Protocol.Types
     , Language.LSP.Protocol.Lens
@@ -51,40 +50,40 @@ library
 
   ghc-options:        -Wall
   build-depends:
-    , aeson                 >=2
-    , async                 >=2.0
-    , attoparsec
-    , base                  >=4.11    && <5
-    , bytestring
-    , co-log-core           >=0.3.1.0
-    , containers
-    , data-default
-    , directory
-    , exceptions
-    , filepath
-    , hashable
-    , lens-aeson
-    , lens                  >=4.15.2
+    , aeson                 >=2      && <2.3
+    , async                 ^>=2.2
+    , attoparsec            ^>=0.14
+    , base                  >=4.11   && <5
+    , bytestring            >=0.10   && <0.13
+    , co-log-core           ^>=0.3
+    , containers            ^>=0.6
+    , data-default          ^>=0.7
+    , directory             ^>=1.3
+    , exceptions            ^>=0.10
+    , filepath              ^>=1.4
+    , hashable              ^>=1.4
+    , lens                  >=5.1    && <5.3
+    , lens-aeson            ^>=1.2
     , lsp-types             ^>=2.1
-    , mtl                   <2.4
-    , prettyprinter
-    , random
-    , row-types
+    , mtl                   ^>=2.3
+    , prettyprinter         ^>=1.7
+    , random                ^>=1.2
+    , row-types             ^>=1.0
     , sorted-list           ^>=0.2.1
     , stm                   ^>=2.5
-    , text
-    , text-rope
-    , transformers          >=0.5.6   && <0.7
-    , unliftio-core         >=0.2.0.0
-    , unordered-containers
+    , text                  >=1      && <2.2
+    , text-rope             ^>=0.2
+    , transformers          >=0.5    && <0.7
+    , unliftio-core         ^>=0.2
+    , unordered-containers  ^>=0.2
     , uuid                  >=1.3
 
 executable lsp-demo-reactor-server
-  main-is:          Reactor.hs
-  hs-source-dirs:   example
-  default-language: Haskell2010
+  main-is:            Reactor.hs
+  hs-source-dirs:     example
+  default-language:   Haskell2010
   default-extensions: ImportQualifiedPost
-  ghc-options:      -Wall -Wno-unticked-promoted-constructors
+  ghc-options:        -Wall -Wno-unticked-promoted-constructors
   build-depends:
     , aeson
     , base
@@ -100,11 +99,11 @@ executable lsp-demo-reactor-server
     buildable: False
 
 executable lsp-demo-simple-server
-  main-is:          Simple.hs
-  hs-source-dirs:   example
-  default-language: Haskell2010
+  main-is:            Simple.hs
+  hs-source-dirs:     example
+  default-language:   Haskell2010
   default-extensions: ImportQualifiedPost
-  ghc-options:      -Wall -Wno-unticked-promoted-constructors
+  ghc-options:        -Wall -Wno-unticked-promoted-constructors
   build-depends:
     , base
     , lsp

--- a/lsp/src/Language/LSP/Server/Processing.hs
+++ b/lsp/src/Language/LSP/Server/Processing.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeInType #-}
+{-# LANGUAGE TypeOperators #-}
 -- So we can keep using the old prettyprinter modules (which have a better
 -- compatibility range) for now.
 {-# OPTIONS_GHC -Wno-deprecations #-}


### PR DESCRIPTION
We really should have these...

I'm going to make sure I can still build HLS on all versions with these in place before committing.