### PR TITLE
More cabal file tidying

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
-index-state: 2023-11-13T00:00:00Z
+index-state: 2023-12-23T00:00:00Z
 
 packages:
          ./lsp
@@ -17,9 +17,3 @@ package lsp-types
   -- This makes a big difference here as lsp-types
   -- has very many independent modules 
   ghc-options: -j4
-
-if impl(ghc >= 9.7)
-  -- https://github.com/kcsongor/generic-lens/issues/158
-  allow-newer: 
-    generic-lens:text,
-    generic-lens-core:text,

--- a/cabal.project
+++ b/cabal.project
@@ -17,3 +17,7 @@ package lsp-types
   -- This makes a big difference here as lsp-types
   -- has very many independent modules 
   ghc-options: -j4
+
+-- We allow filepath-1.5, this lets us actually test it. There is no problem
+-- on the lens side.
+allow-newer: lens:filepath

--- a/lsp-test/lsp-test.cabal
+++ b/lsp-test/lsp-test.cabal
@@ -99,7 +99,7 @@ test-suite tests
   other-modules:      DummyServer
   build-depends:
     , aeson
-    , base                >=4.10 && <5
+    , base
     , containers
     , data-default
     , directory

--- a/lsp-test/lsp-test.cabal
+++ b/lsp-test/lsp-test.cabal
@@ -45,7 +45,7 @@ library
   build-depends:
     , aeson               >=2     && <2.3
     , aeson-pretty        ^>=0.8
-    , ansi-terminal       >= 0.10 && < 1.1
+    , ansi-terminal       >=0.10  && <1.1
     , async               ^>=2.2
     , base                >=4.10  && <5
     , bytestring          >=0.10  && <0.13
@@ -54,7 +54,7 @@ library
     , conduit-parse       ^>=0.2
     , containers          ^>=0.6
     , data-default        ^>=0.7
-    , Diff                >= 0.4 && < 0.6
+    , Diff                >=0.4   && <0.6
     , directory           ^>=1.3
     , exceptions          ^>=0.10
     , filepath            ^>=1.4
@@ -63,7 +63,7 @@ library
     , lens-aeson          ^>=1.2
     , lsp                 ^>=2.3
     , lsp-types           ^>=2.1
-    , mtl                 >= 2.2 && < 2.4
+    , mtl                 >=2.2   && <2.4
     , parser-combinators  ^>=1.3
     , process             ^>=1.6
     , row-types           ^>=1.0
@@ -106,9 +106,9 @@ test-suite tests
     , filepath
     , hspec
     , lens
-    , lsp                 ^>=2.3
+    , lsp
     , lsp-test
-    , mtl                 <2.4
+    , mtl
     , parser-combinators
     , process
     , text

--- a/lsp-test/lsp-test.cabal
+++ b/lsp-test/lsp-test.cabal
@@ -57,7 +57,7 @@ library
     , Diff                >=0.4   && <0.6
     , directory           ^>=1.3
     , exceptions          ^>=0.10
-    , filepath            ^>=1.4
+    , filepath            >=1.4 && < 1.6
     , Glob                >=0.9   && <0.11
     , lens                >=5.1   && <5.3
     , lens-aeson          ^>=1.2

--- a/lsp-types/lsp-types.cabal
+++ b/lsp-types/lsp-types.cabal
@@ -551,7 +551,7 @@ executable generator
   main-is:            Main.hs
   other-modules:      CodeGen
   build-depends:
-    , base                 >=4.11 && <5
+    , base
     , containers
     , directory
     , filepath

--- a/lsp-types/lsp-types.cabal
+++ b/lsp-types/lsp-types.cabal
@@ -76,7 +76,7 @@ library
     , containers                     ^>=0.6
     , data-default                   ^>=0.7
     , deepseq                        >=1.4   && <1.6
-    , Diff                           >= 0.4 && < 0.6
+    , Diff                           >=0.4   && <0.6
     , dlist                          ^>=1.0
     , exceptions                     ^>=0.10
     , hashable                       ^>=1.4
@@ -85,7 +85,7 @@ library
     , lens                           >=5.1   && <5.3
     , lens-aeson                     ^>=1.2
     , mod                            ^>=0.2
-    , mtl                            >= 2.2 && < 2.4
+    , mtl                            >=2.2   && <2.4
     , network-uri                    ^>=2.6
     , prettyprinter                  ^>=1.7
     , row-types                      ^>=1.0
@@ -94,11 +94,14 @@ library
     , template-haskell               >=2.7   && <2.22
     , text                           >=1     && <2.2
 
+  -- This version of filepath comes with GHC 9.6, so
+  -- we should be able to drop this flag once we only
+  -- support 9.6 or higher
   if flag(force-ospath)
     build-depends: filepath ^>=1.4.100.0
 
   else
-    build-depends: filepath
+    build-depends: filepath ^>=1.4
 
   ghc-options:
     -Wall -Wmissing-deriving-strategies
@@ -532,11 +535,11 @@ library metamodel
 
   build-depends:
     , aeson             >=2
-    , base              >=4.11   && <5
-    , file-embed
-    , lens              >=4.15.2
-    , template-haskell
-    , text
+    , base              >=4.11    && <5
+    , file-embed        ^>=0.0.15
+    , lens              >=5.1     && <5.3
+    , template-haskell  >=2.7     && <2.22
+    , text              >=1       && <2.2
 
 executable generator
   hs-source-dirs:     generator
@@ -578,11 +581,11 @@ test-suite lsp-types-test
 
   ghc-options:        -threaded -rtsopts -with-rtsopts=-N -Wall
   build-depends:
-    , aeson                 >=2.0.3.0
+    , aeson
     , base
     , filepath
     , hspec
-    , lens                  >=4.15.2
+    , lens
     , lsp-types
     , network-uri
     , QuickCheck

--- a/lsp-types/lsp-types.cabal
+++ b/lsp-types/lsp-types.cabal
@@ -98,10 +98,10 @@ library
   -- we should be able to drop this flag once we only
   -- support 9.6 or higher
   if flag(force-ospath)
-    build-depends: filepath ^>=1.4.100.0
+    build-depends: filepath >=1.4.100.0 && < 1.6
 
   else
-    build-depends: filepath ^>=1.4
+    build-depends: filepath >=1.4 && < 1.6
 
   ghc-options:
     -Wall -Wmissing-deriving-strategies

--- a/lsp/lsp.cabal
+++ b/lsp/lsp.cabal
@@ -65,7 +65,7 @@ library
     , lens                  >=5.1    && <5.3
     , lens-aeson            ^>=1.2
     , lsp-types             ^>=2.1
-    , mtl                   >= 2.2 && < 2.4
+    , mtl                   >=2.2    && <2.4
     , prettyprinter         ^>=1.7
     , random                ^>=1.2
     , row-types             ^>=1.0
@@ -88,7 +88,7 @@ executable lsp-demo-reactor-server
     , aeson
     , base
     , co-log-core
-    , lens           >=4.15.2
+    , lens
     , lsp
     , prettyprinter
     , stm
@@ -132,7 +132,7 @@ test-suite lsp-test
     , hspec
     , lsp
     , row-types
-    , sorted-list           >=0.2.1 && <0.2.3
+    , sorted-list
     , text
     , text-rope
     , unordered-containers

--- a/lsp/lsp.cabal
+++ b/lsp/lsp.cabal
@@ -60,7 +60,7 @@ library
     , data-default          ^>=0.7
     , directory             ^>=1.3
     , exceptions            ^>=0.10
-    , filepath              ^>=1.4
+    , filepath              >=1.4 && < 1.6
     , hashable              ^>=1.4
     , lens                  >=5.1    && <5.3
     , lens-aeson            ^>=1.2


### PR DESCRIPTION
Remove most constraints from non-library components. I'm unsure if this is quite right: possibly we should have bounds for any public component, but this is significantly more work to maintain (witness the odd bound on `sorted-list` from a test suite). I think this strikes a reasonable balance for now.