### PR TITLE
release lsp types 1.6.0.1

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -6,8 +6,6 @@ packages:
 package lsp
   flags: +demo
 
-index-state: 2022-08-25T22:25:05Z
-
 tests: True
 benchmarks: True
 test-show-details: direct

--- a/lsp-types/ChangeLog.md
+++ b/lsp-types/ChangeLog.md
@@ -1,22 +1,26 @@
 # Revision history for lsp-types
 
-## 1.6.0.0
+## 1.6.0.1 -- 2023-12-02
+
+* Add `LANGUAGE DuplicateRecordFields` to facilitate building with GHC 9.8
+
+## 1.6.0.0 -- 2022-09-13
 
 * Add `isSubRangeOf` and `positionInRange` helper functions
 * Add `ServerCancelled`, `RequestFailed` and `ErrorCodeCustom` server error types
 * Fix "workspace/semanticTokens/refresh" to be a server method instead of a client method
 * Use a packed representation for `NormalizedFilePath`
 * Add converions from `OsPath` to `NormalizedFilePath` in `Language.LSP.Types.Uri.OsPath` when using new enough `filepath`
- 
-## 1.5.0.0
+
+## 1.5.0.0 -- 2022-06-20
 
 * VFS module moved from `lsp-types` to `lsp`, as it relates to the actual implementation of a LSP server.
 
-## 1.4.0.1
+## 1.4.0.1 -- 2022-01-20
 
 * Fix result type of selection range requests.
 
-## 1.4.0.0
+## 1.4.0.0 -- 2021-12-28
 
 * Aeson 2 compatibility (#360) (@michaelpj)
 * Reduced dependency footprint (#383, #384) (@Bodigrim)
@@ -26,15 +30,15 @@
 * Fix the Semigroup instance for MarkupContent (#361) (@michaelpj)
 * Various improvements to spec conformance (@michaelpj)
 
-## 1.3.0.1
+## 1.3.0.1 -- 2021-08-06
 
 * Rollback NFP interning (#344) (@pepeiborra)
 
-## 1.3.0.0
+## 1.3.0.0 -- 2021-07-31
 
 * Intern NormalizedFilePaths (#340) (@pepeiborra)
 
-## 1.2.0.1
+## 1.2.0.1 -- unpublished
 
 * Add compatibility with GHC 9.2 (#345) (@fendor)
 * Fix missing lenses (@michaelpj)
@@ -44,7 +48,7 @@
 * Do not crash on workspace/didChangeConfiguration (#321) (@strager)
 * Improve error messages on JSON decode failures (#320) (@strager)
 
-## 1.2.0.0
+## 1.2.0.0 -- 2021-03-28
 
 * Prevent crashing when optional fields are missing (@anka-213)
 * Use StrictData (@wz1000)
@@ -61,7 +65,7 @@
 * Support change annotations (#302) (@michaelpj)
 * Add some more missing lenses (#307) (@michaelpj)
 
-## 1.1.0.0
+## 1.1.0.0 -- 2021-02-14
 
 * Fix prepareRename reponse and prepareProvider (@kirelagin)
 * Fix deriving instance of MonadUnliftIO (@banacorn)
@@ -94,7 +98,7 @@ type DocumentChange = TextDocumentEdit |? CreateFile |? RenameFile |? DeleteFile
 * Use Text over String in more places (@wz1000)
 * Add missing lenses (@wz1000, @bubba)
 
-## 1.0.0.0
+## 1.0.0.0 -- 2020-10-15
 
 1.0.0.0 is a major rework with both internal and external facing changes, and
 will require manual migration.
@@ -193,10 +197,10 @@ can use the result returned from `doInitialize` to pass along the
 `LanguageContextEnv` needed to run an `LspT`, as well as anything else your
 monad needs.
 ```haskell
-type 
+type
 ServerDefinition { ...
 , doInitialize = \env _req -> pure $ Right env
-, interpretHandler = \env -> Iso 
+, interpretHandler = \env -> Iso
    (runLspT env) -- how to convert from IO ~> m
    liftIO        -- how to convert from m ~> IO
 }
@@ -212,7 +216,7 @@ ServerDefinition { ...
 5. Remove any storage/use of `LspFuncs` and instead call the corresponding
    functions directly from your monad instead of `IO`
 
-## 0.23.0.0
+## 0.23.0.0 -- 2020-10-05
 
 * Add runWith for transporots other than stdio (@paulyoung)
 * Fix race condition in event captures (@bgamari)
@@ -223,12 +227,12 @@ ServerDefinition { ...
   NormalizedFilePath (@cocreature)
 * Fix ordering of TH splices (@fendor)
 
-## 0.22.0.0
+## 0.22.0.0 -- 2020-05-04
 
 * ResponseMessage results are now an Either type (@greenhat)
 * Support for GHC 8.10.1
 
-## 0.21.0.0
+## 0.21.0.0 -- 2020-03-21
 
 * Stop getCompletionPrefix from crashing if beforePos is empty
 * Add DidChangeWatchedFilesRegistrationOptions
@@ -238,7 +242,7 @@ ServerDefinition { ...
 * Correctly fix the problem with '$/' notifications
 * Add azure ci
 
-## 0.20.0.0
+## 0.20.0.0 -- 2020-02-04T
 
 * Force utf8 encoding when writing vfs temp files
 * Don't log errors for '$/' notifications (@jinwoo)
@@ -298,7 +302,7 @@ ServerDefinition { ...
 
 * Add types for `window/progress` notifications.
 
-## 0.8.3.0
+## 0.8.3.0 -- unpublished
 
 * Add `MarkupContent` to `HoverResponse`, and (some) json roundtrip tests.
 
@@ -351,11 +355,11 @@ ServerDefinition { ...
 * CodeAction support as per v3.8 of the specification, by @Bubba
 * Update VersionedTextDocumentIdentifier to match specification, by @Bubba.
 
-## 0.3.0.0
+## 0.3.0.0 -- unpublished
 
 * Handle TextDocumentSync fallbacks with new TDS type.
 
-## 0.2.3.0
+## 0.2.3.0 -- unpublished
 
 * GHC 8.4.3 support
 * Introduce additional error codes as per the LSP spec. By @Bubba

--- a/lsp-types/lsp-types.cabal
+++ b/lsp-types/lsp-types.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                lsp-types
-version:             1.6.0.0
+version:             1.6.0.1
 synopsis:            Haskell library for the Microsoft Language Server Protocol, data types
 
 description:         An implementation of the types to allow language implementors to
@@ -102,7 +102,9 @@ library
     build-depends: filepath
   hs-source-dirs:      src
   default-language:    Haskell2010
-  default-extensions: StrictData
+  default-extensions:
+    DuplicateRecordFields
+    StrictData
 
 test-suite lsp-types-test
   type:                exitcode-stdio-1.0

--- a/lsp/lsp.cabal
+++ b/lsp/lsp.cabal
@@ -48,7 +48,7 @@ library
                      , lens >= 4.15.2
                      , mtl < 2.4
                      , prettyprinter
-                     , sorted-list == 0.2.1.*
+                     , sorted-list ^>= 0.2.1
                      , stm == 2.5.*
                      , temporary
                      , text
@@ -69,10 +69,10 @@ executable lsp-demo-reactor-server
   default-language:    Haskell2010
   ghc-options:         -Wall -Wno-unticked-promoted-constructors
 
-  build-depends:       base 
+  build-depends:       base
                      , aeson
                      , co-log-core
-                     , lens >= 4.15.2
+                     , lens
                      , stm
                      , prettyprinter
                      , text
@@ -86,7 +86,7 @@ executable lsp-demo-simple-server
   hs-source-dirs:      example
   default-language:    Haskell2010
   ghc-options:         -Wall -Wno-unticked-promoted-constructors
-  build-depends:       base 
+  build-depends:       base
                     -- the package library. Comment this out if you want repl changes to propagate
                      , lsp
                      , text
@@ -109,7 +109,7 @@ test-suite lsp-test
                      , containers
                      , lsp
                      , hspec
-                     , sorted-list == 0.2.1.*
+                     , sorted-list
                      , text
                      , text-rope
                      , unordered-containers


### PR DESCRIPTION
- lsp-1.6.0.0: remove obsolete bounds from lsp.cabal (as in revision)
- lsp-types-1.6.0.1: add `DuplicateRecordFields` extension for GHC 9.8
- lsp-types/changelog: add 1.6.0.1 and missing dates of previous releases
