### PR TITLE
Avoid couple partial functions in lsp-test

### DIFF
--- a/lsp-test/src/Language/LSP/Test.hs
+++ b/lsp-test/src/Language/LSP/Test.hs
@@ -421,7 +421,7 @@ sendRequest method params = do
   reqMap <- requestMap <$> ask
   liftIO $
     modifyMVar_ reqMap $
-      \r -> return $ fromJust $ updateRequestMap r id method
+      \r -> return $ fromMaybe r $ updateRequestMap r id method
 
   ~() <- case splitClientMethod method of
     IsClientReq -> sendMessage mess


### PR DESCRIPTION
Was anyone able to figure out why there are sometimes timeout messages of the following king in hls test suite?

```
Test suite tests: RUNNING...
eval
  Property checking:                                            FAIL (66.02s)
    Timed out waiting to receive a message from the server.
    Last message received:
    {
        "jsonrpc": "2.0",
        "method": "$/progress",
        "params": {
            "token": "28",
            "value": {
                "kind": "end",
                "message": "Finished indexing 5 files"
            }
        }
    }
    Use -p '/Property checking/' to rerun this test only.
```


U briefly checked how lsp-test works and was surprised by the amount of partial functions used.
Here's a few easy to replace occurrences of fromJust + couple hard-to-resist hlint suggestions.