### PR TITLE
Remove deprecated prettyprinter usage

### DIFF
--- a/lsp/example/Reactor.hs
+++ b/lsp/example/Reactor.hs
@@ -4,9 +4,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeInType #-}
--- So we can keep using the old prettyprinter modules (which have a better
--- compatibility range) for now.
-{-# OPTIONS_GHC -Wno-deprecations #-}
 
 {- |
 This is an example language server built with haskell-lsp using a 'Reactor'
@@ -36,7 +33,7 @@ import Control.Monad.STM
 import Data.Aeson qualified as J
 import Data.Int (Int32)
 import Data.Text qualified as T
-import Data.Text.Prettyprint.Doc
+import Prettyprinter
 import GHC.Generics (Generic)
 import Language.LSP.Diagnostics
 import Language.LSP.Logging (defaultClientLogger)

--- a/lsp/example/Reactor.hs
+++ b/lsp/example/Reactor.hs
@@ -33,7 +33,6 @@ import Control.Monad.STM
 import Data.Aeson qualified as J
 import Data.Int (Int32)
 import Data.Text qualified as T
-import Prettyprinter
 import GHC.Generics (Generic)
 import Language.LSP.Diagnostics
 import Language.LSP.Logging (defaultClientLogger)
@@ -42,6 +41,7 @@ import Language.LSP.Protocol.Message qualified as LSP
 import Language.LSP.Protocol.Types qualified as LSP
 import Language.LSP.Server
 import Language.LSP.VFS
+import Prettyprinter
 import System.Exit
 import System.IO
 

--- a/lsp/src/Language/LSP/Server/Control.hs
+++ b/lsp/src/Language/LSP/Server/Control.hs
@@ -27,12 +27,12 @@ import Data.List
 import Data.Text qualified as T
 import Data.Text.Lazy qualified as TL
 import Data.Text.Lazy.Encoding qualified as TL
-import Prettyprinter
 import Language.LSP.Logging (defaultClientLogger)
 import Language.LSP.Protocol.Message
 import Language.LSP.Server.Core
 import Language.LSP.Server.Processing qualified as Processing
 import Language.LSP.VFS
+import Prettyprinter
 import System.IO
 
 data LspServerLog

--- a/lsp/src/Language/LSP/Server/Control.hs
+++ b/lsp/src/Language/LSP/Server/Control.hs
@@ -1,8 +1,5 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
--- So we can keep using the old prettyprinter modules (which have a better
--- compatibility range) for now.
-{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module Language.LSP.Server.Control (
   -- * Running
@@ -30,7 +27,7 @@ import Data.List
 import Data.Text qualified as T
 import Data.Text.Lazy qualified as TL
 import Data.Text.Lazy.Encoding qualified as TL
-import Data.Text.Prettyprint.Doc
+import Prettyprinter
 import Language.LSP.Logging (defaultClientLogger)
 import Language.LSP.Protocol.Message
 import Language.LSP.Server.Core

--- a/lsp/src/Language/LSP/Server/Processing.hs
+++ b/lsp/src/Language/LSP/Server/Processing.hs
@@ -50,7 +50,6 @@ import Data.Monoid
 import Data.String (fromString)
 import Data.Text qualified as T
 import Data.Text.Lazy.Encoding qualified as TL
-import Prettyprinter
 import Language.LSP.Protocol.Lens qualified as L
 import Language.LSP.Protocol.Message
 import Language.LSP.Protocol.Types
@@ -58,6 +57,7 @@ import Language.LSP.Protocol.Utils.SMethodMap (SMethodMap)
 import Language.LSP.Protocol.Utils.SMethodMap qualified as SMethodMap
 import Language.LSP.Server.Core
 import Language.LSP.VFS as VFS
+import Prettyprinter
 import System.Exit
 
 data LspProcessingLog

--- a/lsp/src/Language/LSP/Server/Processing.hs
+++ b/lsp/src/Language/LSP/Server/Processing.hs
@@ -4,9 +4,6 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE RecursiveDo #-}
 {-# LANGUAGE TypeInType #-}
--- So we can keep using the old prettyprinter modules (which have a better
--- compatibility range) for now.
-{-# OPTIONS_GHC -Wno-deprecations #-}
 -- there's just so much!
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
@@ -53,7 +50,7 @@ import Data.Monoid
 import Data.String (fromString)
 import Data.Text qualified as T
 import Data.Text.Lazy.Encoding qualified as TL
-import Data.Text.Prettyprint.Doc
+import Prettyprinter
 import Language.LSP.Protocol.Lens qualified as L
 import Language.LSP.Protocol.Message
 import Language.LSP.Protocol.Types

--- a/lsp/src/Language/LSP/VFS.hs
+++ b/lsp/src/Language/LSP/VFS.hs
@@ -6,9 +6,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeInType #-}
 {-# LANGUAGE ViewPatterns #-}
--- So we can keep using the old prettyprinter modules (which have a better
--- compatibility range) for now.
-{-# OPTIONS_GHC -Wno-deprecations #-}
 
 {- |
 Handles the "Language.LSP.Types.TextDocumentDidChange" \/
@@ -70,7 +67,7 @@ import Data.Ord
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.IO qualified as T
-import Data.Text.Prettyprint.Doc hiding (line)
+import Prettyprinter hiding (line)
 import Data.Text.Utf16.Lines as Utf16 (Position (..))
 import Data.Text.Utf16.Rope.Mixed (Rope)
 import Data.Text.Utf16.Rope.Mixed qualified as Rope

--- a/lsp/src/Language/LSP/VFS.hs
+++ b/lsp/src/Language/LSP/VFS.hs
@@ -67,13 +67,13 @@ import Data.Ord
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.IO qualified as T
-import Prettyprinter hiding (line)
 import Data.Text.Utf16.Lines as Utf16 (Position (..))
 import Data.Text.Utf16.Rope.Mixed (Rope)
 import Data.Text.Utf16.Rope.Mixed qualified as Rope
 import Language.LSP.Protocol.Lens qualified as J
 import Language.LSP.Protocol.Message qualified as J
 import Language.LSP.Protocol.Types qualified as J
+import Prettyprinter hiding (line)
 import System.Directory
 import System.FilePath
 import System.IO


### PR DESCRIPTION
We've been requiring the latest major version for a while anyway.