### PR TITLE
Rewrite progress handling to allow for debouncing messages

### DIFF
--- a/lsp-test/func-test/FuncTest.hs
+++ b/lsp-test/func-test/FuncTest.hs
@@ -8,6 +8,7 @@ module Main where
 import Colog.Core
 import Colog.Core qualified as L
 import Control.Applicative.Combinators
+import Control.Concurrent.Extra (newBarrier, signalBarrier, waitBarrier)
 import Control.Exception
 import Control.Lens hiding (Iso, List)
 import Control.Monad
@@ -53,7 +54,10 @@ spec = do
   let logger = L.cmap show L.logStringStderr
   describe "server-initiated progress reporting" $ do
     it "sends updates" $ do
-      startBarrier <- newEmptyMVar
+      startBarrier <- newBarrier
+      b1 <- newBarrier
+      b2 <- newBarrier
+      b3 <- newBarrier
 
       let definition =
             ServerDefinition
@@ -71,10 +75,13 @@ spec = do
           handlers =
             requestHandler (SMethod_CustomMethod (Proxy @"something")) $ \_req resp -> void $ forkIO $ do
               withProgress "Doing something" Nothing NotCancellable $ \updater -> do
-                takeMVar startBarrier
+                liftIO $ waitBarrier startBarrier
                 updater $ ProgressAmount (Just 25) (Just "step1")
+                liftIO $ waitBarrier b1
                 updater $ ProgressAmount (Just 50) (Just "step2")
+                liftIO $ waitBarrier b2
                 updater $ ProgressAmount (Just 75) (Just "step3")
+                liftIO $ waitBarrier b3
 
       runSessionWithServer logger definition Test.defaultConfig Test.fullCaps "." $ do
         Test.sendRequest (SMethod_CustomMethod (Proxy @"something")) J.Null
@@ -86,25 +93,28 @@ spec = do
           guard $ has (L.params . L.value . _workDoneProgressBegin) x
 
         -- allow the hander to send us updates
-        putMVar startBarrier ()
+        liftIO $ signalBarrier startBarrier ()
 
         do
           u <- Test.message SMethod_Progress
           liftIO $ do
             u ^? L.params . L.value . _workDoneProgressReport . L.message `shouldBe` Just (Just "step1")
             u ^? L.params . L.value . _workDoneProgressReport . L.percentage `shouldBe` Just (Just 25)
+        liftIO $ signalBarrier b1 ()
 
         do
           u <- Test.message SMethod_Progress
           liftIO $ do
             u ^? L.params . L.value . _workDoneProgressReport . L.message `shouldBe` Just (Just "step2")
             u ^? L.params . L.value . _workDoneProgressReport . L.percentage `shouldBe` Just (Just 50)
+        liftIO $ signalBarrier b2 ()
 
         do
           u <- Test.message SMethod_Progress
           liftIO $ do
             u ^? L.params . L.value . _workDoneProgressReport . L.message `shouldBe` Just (Just "step3")
             u ^? L.params . L.value . _workDoneProgressReport . L.percentage `shouldBe` Just (Just 75)
+        liftIO $ signalBarrier b3 ()
 
         -- Then make sure we get a $/progress end notification
         skipManyTill Test.anyMessage $ do
@@ -132,7 +142,7 @@ spec = do
               -- Doesn't matter what cancellability we set here!
               withProgress "Doing something" Nothing NotCancellable $ \updater -> do
                 -- Wait around to be cancelled, set the MVar only if we are
-                liftIO $ threadDelay (1 * 1000000) `Control.Exception.catch` (\(e :: ProgressCancelledException) -> modifyMVar_ wasCancelled (\_ -> pure True))
+                liftIO $ threadDelay (5 * 1000000) `Control.Exception.catch` (\(e :: ProgressCancelledException) -> modifyMVar_ wasCancelled (\_ -> pure True))
 
       runSessionWithServer logger definition Test.defaultConfig Test.fullCaps "." $ do
         Test.sendRequest (SMethod_CustomMethod (Proxy @"something")) J.Null
@@ -196,6 +206,11 @@ spec = do
 
   describe "client-initiated progress reporting" $ do
     it "sends updates" $ do
+      startBarrier <- newBarrier
+      b1 <- newBarrier
+      b2 <- newBarrier
+      b3 <- newBarrier
+
       let definition =
             ServerDefinition
               { parseConfig = const $ const $ Right ()
@@ -212,9 +227,13 @@ spec = do
           handlers =
             requestHandler SMethod_TextDocumentCodeLens $ \req resp -> void $ forkIO $ do
               withProgress "Doing something" (req ^. L.params . L.workDoneToken) NotCancellable $ \updater -> do
+                liftIO $ waitBarrier startBarrier
                 updater $ ProgressAmount (Just 25) (Just "step1")
+                liftIO $ waitBarrier b1
                 updater $ ProgressAmount (Just 50) (Just "step2")
+                liftIO $ waitBarrier b2
                 updater $ ProgressAmount (Just 75) (Just "step3")
+                liftIO $ waitBarrier b3
 
       runSessionWithServer logger definition Test.defaultConfig Test.fullCaps "." $ do
         Test.sendRequest SMethod_TextDocumentCodeLens (CodeLensParams (Just $ ProgressToken $ InR "hello") Nothing (TextDocumentIdentifier $ Uri "."))
@@ -224,23 +243,28 @@ spec = do
           x <- Test.message SMethod_Progress
           guard $ has (L.params . L.value . _workDoneProgressBegin) x
 
+        liftIO $ signalBarrier startBarrier ()
+
         do
           u <- Test.message SMethod_Progress
           liftIO $ do
             u ^? L.params . L.value . _workDoneProgressReport . L.message `shouldBe` Just (Just "step1")
             u ^? L.params . L.value . _workDoneProgressReport . L.percentage `shouldBe` Just (Just 25)
+        liftIO $ signalBarrier b1 ()
 
         do
           u <- Test.message SMethod_Progress
           liftIO $ do
             u ^? L.params . L.value . _workDoneProgressReport . L.message `shouldBe` Just (Just "step2")
             u ^? L.params . L.value . _workDoneProgressReport . L.percentage `shouldBe` Just (Just 50)
+        liftIO $ signalBarrier b2 ()
 
         do
           u <- Test.message SMethod_Progress
           liftIO $ do
             u ^? L.params . L.value . _workDoneProgressReport . L.message `shouldBe` Just (Just "step3")
             u ^? L.params . L.value . _workDoneProgressReport . L.percentage `shouldBe` Just (Just 75)
+        liftIO $ signalBarrier b3 ()
 
         -- Then make sure we get a $/progress end notification
         skipManyTill Test.anyMessage $ do

--- a/lsp-test/lsp-test.cabal
+++ b/lsp-test/lsp-test.cabal
@@ -128,6 +128,7 @@ test-suite func-test
     , base
     , aeson
     , co-log-core
+    , extra
     , hspec
     , lens
     , lsp

--- a/lsp-test/lsp-test.cabal
+++ b/lsp-test/lsp-test.cabal
@@ -65,7 +65,7 @@ library
     , Glob                >=0.9   && <0.11
     , lens                >=5.1   && <5.3
     , lens-aeson          ^>=1.2
-    , lsp                 ^>=2.5
+    , lsp                 ^>=2.6
     , lsp-types           ^>=2.2
     , mtl                 >=2.2   && <2.4
     , parser-combinators  ^>=1.3

--- a/lsp/ChangeLog.md
+++ b/lsp/ChangeLog.md
@@ -1,5 +1,11 @@
 # Revision history for lsp
 
+## Unreleased
+
+- Progress reporting now has a configurable start delay and update delay. This allows
+  servers to set up progress reporting for any operation and not worry about spamming
+  the user with extremely short-lived progress sessions.
+
 ## 2.5.0.0
 
 - The server will now reject messages sent after `shutdown` has been received.

--- a/lsp/ChangeLog.md
+++ b/lsp/ChangeLog.md
@@ -1,6 +1,6 @@
 # Revision history for lsp
 
-## Unreleased
+## 2.6.0.0
 
 - Progress reporting now has a configurable start delay and update delay. This allows
   servers to set up progress reporting for any operation and not worry about spamming

--- a/lsp/lsp.cabal
+++ b/lsp/lsp.cabal
@@ -50,6 +50,7 @@ library
     Language.LSP.Server.Control
     Language.LSP.Server.Core
     Language.LSP.Server.Processing
+    Language.LSP.Server.Progress
 
   build-depends:
     , aeson                 >=2      && <2.3

--- a/lsp/lsp.cabal
+++ b/lsp/lsp.cabal
@@ -76,6 +76,7 @@ library
     , text                  >=1      && <2.2
     , text-rope             ^>=0.2
     , transformers          >=0.5    && <0.7
+    , unliftio              ^>=0.2
     , unliftio-core         ^>=0.2
     , unordered-containers  ^>=0.2
     , uuid                  >=1.3

--- a/lsp/lsp.cabal
+++ b/lsp/lsp.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               lsp
-version:            2.5.0.0
+version:            2.6.0.0
 synopsis:           Haskell library for the Microsoft Language Server Protocol
 description:
   An implementation of the types, and basic message server to

--- a/lsp/src/Language/LSP/Server.hs
+++ b/lsp/src/Language/LSP/Server.hs
@@ -67,3 +67,4 @@ module Language.LSP.Server (
 
 import Language.LSP.Server.Control
 import Language.LSP.Server.Core
+import Language.LSP.Server.Progress

--- a/lsp/src/Language/LSP/Server/Core.hs
+++ b/lsp/src/Language/LSP/Server/Core.hs
@@ -19,10 +19,8 @@ import Colog.Core (
   WithSeverity (..),
   (<&),
  )
-import Control.Concurrent.Async
 import Control.Concurrent.Extra as C
 import Control.Concurrent.STM
-import Control.Exception qualified as E
 import Control.Lens (at, (^.), (^?), _Just)
 import Control.Monad
 import Control.Monad.Catch (
@@ -38,7 +36,6 @@ import Control.Monad.Trans.Identity
 import Control.Monad.Trans.Reader
 import Data.Aeson qualified as J
 import Data.Default
-import Data.Foldable
 import Data.Functor.Product
 import Data.HashMap.Strict qualified as HM
 import Data.IxMap
@@ -65,8 +62,6 @@ import Language.LSP.Protocol.Utils.SMethodMap qualified as SMethodMap
 import Language.LSP.VFS hiding (end)
 import Prettyprinter
 import System.Random hiding (next)
-import UnliftIO qualified as U
-import UnliftIO.Exception qualified as UE
 
 -- ---------------------------------------------------------------------
 {-# ANN module ("HLint: ignore Eta reduce" :: String) #-}
@@ -322,29 +317,6 @@ instance Default Options where
 
 defaultOptions :: Options
 defaultOptions = def
-
-{- | A package indicating the percentage of progress complete and a
- an optional message to go with it during a 'withProgress'
-
- @since 0.10.0.0
--}
-data ProgressAmount = ProgressAmount (Maybe UInt) (Maybe Text)
-
-{- | Thrown if the user cancels a 'Cancellable' 'withProgress'/'withIndefiniteProgress'/ session
-
- @since 0.11.0.0
--}
-data ProgressCancelledException = ProgressCancelledException
-  deriving (Show)
-
-instance E.Exception ProgressCancelledException
-
-{- | Whether or not the user should be able to cancel a 'withProgress'/'withIndefiniteProgress'
- session
-
- @since 0.11.0.0
--}
-data ProgressCancellable = Cancellable | NotCancellable
 
 -- See Note [LSP configuration] for discussion of the configuration-related fields
 
@@ -644,194 +616,6 @@ unregisterCapability (RegistrationToken m (RegistrationId uuid)) = do
   let unregistration = L.TUnregistration uuid m
       params = L.UnregistrationParams [toUntypedUnregistration unregistration]
   void $ sendRequest SMethod_ClientUnregisterCapability params $ \_res -> pure ()
-
---------------------------------------------------------------------------------
--- PROGRESS
---------------------------------------------------------------------------------
-
--- Get a new id for the progress session and make a new one
-getNewProgressId :: MonadLsp config m => m ProgressToken
-getNewProgressId = do
-  stateState (progressNextId . resProgressData) $ \cur ->
-    let !next = cur + 1
-     in (L.ProgressToken $ L.InL cur, next)
-{-# INLINE getNewProgressId #-}
-
-withProgressBase ::
-  forall c m a.
-  MonadLsp c m =>
-  Bool ->
-  Text ->
-  Maybe ProgressToken ->
-  ProgressCancellable ->
-  ((ProgressAmount -> m ()) -> m a) ->
-  m a
-withProgressBase indefinite title clientToken cancellable f = do
-  let initialProgress = ProgressAmount (if indefinite then Nothing else Just 0) Nothing
-  LanguageContextEnv{resProgressStartDelay = startDelay, resProgressUpdateDelay = updateDelay} <- getLspEnv
-
-  tokenVar <- liftIO newEmptyTMVarIO
-  reportVar <- liftIO $ newTMVarIO initialProgress
-  endBarrier <- liftIO newEmptyMVar
-
-  let
-    updater :: ProgressAmount -> m ()
-    updater pa = liftIO $ atomically $ do
-      -- I don't know of a way to do this with a normal MVar!
-      -- That is: put something into it regardless of whether it is full or empty
-      _ <- tryTakeTMVar reportVar
-      putTMVar reportVar pa
-
-    progressEnded :: IO ()
-    progressEnded = readMVar endBarrier
-
-    endProgress :: IO ()
-    endProgress = void $ tryPutMVar endBarrier ()
-
-    -- Once we have a 'ProgressToken', store it in the variable and also register the cancellation
-    -- handler.
-    registerToken :: ProgressToken -> m ()
-    registerToken t = do
-      handlers <- getProgressCancellationHandlers
-      liftIO $ atomically $ do
-        putTMVar tokenVar t
-        modifyTVar handlers (Map.insert t endProgress)
-
-    -- Deregister our 'ProgressToken', specifically its cancellation handler. It is important
-    -- to do this reliably or else we will leak handlers.
-    unregisterToken :: m ()
-    unregisterToken = do
-      handlers <- getProgressCancellationHandlers
-      liftIO $ atomically $ do
-        mt <- tryReadTMVar tokenVar
-        for_ mt $ \t -> modifyTVar handlers (Map.delete t)
-
-    -- Find and register our 'ProgressToken', asking the client for it if necessary.
-    -- Note that this computation may terminate before we get the token, we need to wait
-    -- for the token var to be filled if we want to use it.
-    createToken :: m ()
-    createToken = do
-      -- See Note [Delayed progress reporting]
-      -- This delays the creation of the token as well as the 'begin' message. Creating
-      -- the token shouldn't result in any visible action on the client side since
-      -- the title/initial percentage aren't given until the 'begin' mesage. However,
-      -- it's neater not to create tokens that we won't use, and clients may find it
-      -- easier to clean them up if they receive begin/end reports for them.
-      liftIO $ threadDelay startDelay
-      case clientToken of
-        -- See Note [Client- versus server-initiated progress]
-        -- Client-initiated progress
-        Just t -> registerToken t
-        -- Try server-initiated progress
-        Nothing -> do
-          t <- getNewProgressId
-          clientCaps <- getClientCapabilities
-
-          -- If we don't have a progress token from the client and
-          -- the client doesn't support server-initiated progress then
-          -- there's nothing to do: we can't report progress.
-          when (clientSupportsServerInitiatedProgress clientCaps)
-            $ void
-            $
-            -- Server-initiated progress
-            -- See Note [Client- versus server-initiated progress]
-            sendRequest
-              SMethod_WindowWorkDoneProgressCreate
-              (WorkDoneProgressCreateParams t)
-            $ \case
-              -- Successfully registered the token, we can now use it.
-              -- So we go ahead and start. We do this as soon as we get the
-              -- token back so the client gets feedback ASAP
-              Right _ -> registerToken t
-              -- The client sent us an error, we can't use the token.
-              Left _err -> pure ()
-
-    -- Actually send the progress reports.
-    sendReports :: m ()
-    sendReports = do
-      t <- liftIO $ atomically $ readTMVar tokenVar
-      begin t
-      -- Once we are sending updates, if we get interrupted we should send
-      -- the end notification
-      update t `UE.finally` end t
-     where
-      cancellable' = case cancellable of
-        Cancellable -> Just True
-        NotCancellable -> Just False
-      begin t = do
-        (ProgressAmount pct msg) <- liftIO $ atomically $ takeTMVar reportVar
-        sendProgressReport t $ WorkDoneProgressBegin L.AString title cancellable' msg pct
-      update t =
-        forever $ do
-          -- See Note [Delayed progress reporting]
-          liftIO $ threadDelay updateDelay
-          (ProgressAmount pct msg) <- liftIO $ atomically $ takeTMVar reportVar
-          sendProgressReport t $ WorkDoneProgressReport L.AString Nothing msg pct
-      end t = sendProgressReport t (WorkDoneProgressEnd L.AString Nothing)
-
-    -- Create the token and then start sending reports; all of which races with the check for the
-    -- progress having ended. In all cases, make sure to unregister the token at the end.
-    progressThreads :: m ()
-    progressThreads =
-      ((createToken >> sendReports) `UE.finally` unregisterToken) `U.race_` liftIO progressEnded
-
-  withRunInIO $ \runInBase -> do
-    withAsync (runInBase $ f updater) $ \mainAct ->
-      -- If the progress gets cancelled then we need to get cancelled too
-      withAsync (runInBase progressThreads) $ \pthreads -> do
-        r <- waitEither mainAct pthreads
-        -- TODO: is this weird? I can't see how else to gracefully use the ending barrier
-        -- as a guard to cancel the other async
-        case r of
-          Left a -> pure a
-          Right _ -> cancelWith mainAct ProgressCancelledException >> wait mainAct
- where
-  sendProgressReport :: (J.ToJSON r) => ProgressToken -> r -> m ()
-  sendProgressReport token report = sendNotification SMethod_Progress $ ProgressParams token $ J.toJSON report
-
-  getProgressCancellationHandlers :: m (TVar (Map.Map ProgressToken (IO ())))
-  getProgressCancellationHandlers = getStateVar (progressCancel . resProgressData)
-
-clientSupportsServerInitiatedProgress :: L.ClientCapabilities -> Bool
-clientSupportsServerInitiatedProgress caps = fromMaybe False $ caps ^? L.window . _Just . L.workDoneProgress . _Just
-{-# INLINE clientSupportsServerInitiatedProgress #-}
-
-{- |
-Wrapper for reporting progress to the client during a long running task.
--}
-withProgress ::
-  MonadLsp c m =>
-  -- | The title of the progress operation
-  Text ->
-  -- | The progress token provided by the client in the method params, if any
-  Maybe ProgressToken ->
-  -- | Whether or not this operation is cancellable. If true, the user will be
-  -- shown a button to allow cancellation. Note that requests can still be cancelled
-  -- even if this is not set.
-  ProgressCancellable ->
-  -- | An update function to pass progress updates to
-  ((ProgressAmount -> m ()) -> m a) ->
-  m a
-withProgress title clientToken cancellable f = withProgressBase False title clientToken cancellable f
-
-{- |
-Same as 'withProgress', but for processes that do not report the precentage complete.
--}
-withIndefiniteProgress ::
-  MonadLsp c m =>
-  -- | The title of the progress operation
-  Text ->
-  -- | The progress token provided by the client in the method params, if any
-  Maybe ProgressToken ->
-  -- | Whether or not this operation is cancellable. If true, the user will be
-  -- shown a button to allow cancellation. Note that requests can still be cancelled
-  -- even if this is not set.
-  ProgressCancellable ->
-  -- | An update function to pass progress updates to
-  ((Text -> m ()) -> m a) ->
-  m a
-withIndefiniteProgress title clientToken cancellable f =
-  withProgressBase True title clientToken cancellable (\update -> f (\msg -> update (ProgressAmount Nothing (Just msg))))
 
 -- ---------------------------------------------------------------------
 

--- a/lsp/src/Language/LSP/Server/Processing.hs
+++ b/lsp/src/Language/LSP/Server/Processing.hs
@@ -172,7 +172,18 @@ initializeRequestHandler logger ServerDefinition{..} vfs sendFunc req = do
       pure LanguageContextState{..}
 
     -- Call the 'duringInitialization' callback to let the server kick stuff up
-    let env = LanguageContextEnv handlers configSection parseConfig configChanger sendFunc stateVars (p ^. L.capabilities) rootDir
+    let env =
+          LanguageContextEnv
+            handlers
+            configSection
+            parseConfig
+            configChanger
+            sendFunc
+            stateVars
+            (p ^. L.capabilities)
+            rootDir
+            (optProgressStartDelay options)
+            (optProgressUpdateDelay options)
         configChanger config = forward interpreter (onConfigChange config)
         handlers = transmuteHandlers interpreter (staticHandlers clientCaps)
         interpreter = interpretHandler initializationResult

--- a/lsp/src/Language/LSP/Server/Progress.hs
+++ b/lsp/src/Language/LSP/Server/Progress.hs
@@ -1,0 +1,237 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Language.LSP.Server.Progress (
+  withProgress,
+  withIndefiniteProgress,
+  ProgressAmount (..),
+  ProgressCancellable (..),
+  ProgressCancelledException,
+) where
+
+import Control.Concurrent.Async
+import Control.Concurrent.Extra as C
+import Control.Concurrent.STM
+import Control.Exception qualified as E
+import Control.Lens hiding (Empty)
+import Control.Monad
+import Control.Monad.IO.Class
+import Control.Monad.IO.Unlift
+import Data.Aeson qualified as J
+import Data.Foldable
+import Data.Map.Strict qualified as Map
+import Data.Maybe
+import Data.Text (Text)
+import Language.LSP.Protocol.Lens qualified as L
+import Language.LSP.Protocol.Message
+import Language.LSP.Protocol.Types
+import Language.LSP.Protocol.Types qualified as L
+import Language.LSP.Server.Core
+import UnliftIO qualified as U
+import UnliftIO.Exception qualified as UE
+
+{- | A package indicating the percentage of progress complete and a
+ an optional message to go with it during a 'withProgress'
+
+ @since 0.10.0.0
+-}
+data ProgressAmount = ProgressAmount (Maybe UInt) (Maybe Text)
+
+{- | Thrown if the user cancels a 'Cancellable' 'withProgress'/'withIndefiniteProgress'/ session
+
+ @since 0.11.0.0
+-}
+data ProgressCancelledException = ProgressCancelledException
+  deriving (Show)
+
+instance E.Exception ProgressCancelledException
+
+{- | Whether or not the user should be able to cancel a 'withProgress'/'withIndefiniteProgress'
+ session
+
+ @since 0.11.0.0
+-}
+data ProgressCancellable = Cancellable | NotCancellable
+
+-- Get a new id for the progress session and make a new one
+getNewProgressId :: MonadLsp config m => m ProgressToken
+getNewProgressId = do
+  stateState (progressNextId . resProgressData) $ \cur ->
+    let !next = cur + 1
+     in (L.ProgressToken $ L.InL cur, next)
+{-# INLINE getNewProgressId #-}
+
+withProgressBase ::
+  forall c m a.
+  MonadLsp c m =>
+  Bool ->
+  Text ->
+  Maybe ProgressToken ->
+  ProgressCancellable ->
+  ((ProgressAmount -> m ()) -> m a) ->
+  m a
+withProgressBase indefinite title clientToken cancellable f = do
+  let initialProgress = ProgressAmount (if indefinite then Nothing else Just 0) Nothing
+  LanguageContextEnv{resProgressStartDelay = startDelay, resProgressUpdateDelay = updateDelay} <- getLspEnv
+
+  tokenVar <- liftIO newEmptyTMVarIO
+  reportVar <- liftIO $ newTMVarIO initialProgress
+  endBarrier <- liftIO newEmptyMVar
+
+  let
+    updater :: ProgressAmount -> m ()
+    updater pa = liftIO $ atomically $ do
+      -- I don't know of a way to do this with a normal MVar!
+      -- That is: put something into it regardless of whether it is full or empty
+      _ <- tryTakeTMVar reportVar
+      putTMVar reportVar pa
+
+    progressEnded :: IO ()
+    progressEnded = readMVar endBarrier
+
+    endProgress :: IO ()
+    endProgress = void $ tryPutMVar endBarrier ()
+
+    -- Once we have a 'ProgressToken', store it in the variable and also register the cancellation
+    -- handler.
+    registerToken :: ProgressToken -> m ()
+    registerToken t = do
+      handlers <- getProgressCancellationHandlers
+      liftIO $ atomically $ do
+        putTMVar tokenVar t
+        modifyTVar handlers (Map.insert t endProgress)
+
+    -- Deregister our 'ProgressToken', specifically its cancellation handler. It is important
+    -- to do this reliably or else we will leak handlers.
+    unregisterToken :: m ()
+    unregisterToken = do
+      handlers <- getProgressCancellationHandlers
+      liftIO $ atomically $ do
+        mt <- tryReadTMVar tokenVar
+        for_ mt $ \t -> modifyTVar handlers (Map.delete t)
+
+    -- Find and register our 'ProgressToken', asking the client for it if necessary.
+    -- Note that this computation may terminate before we get the token, we need to wait
+    -- for the token var to be filled if we want to use it.
+    createToken :: m ()
+    createToken = do
+      -- See Note [Delayed progress reporting]
+      -- This delays the creation of the token as well as the 'begin' message. Creating
+      -- the token shouldn't result in any visible action on the client side since
+      -- the title/initial percentage aren't given until the 'begin' mesage. However,
+      -- it's neater not to create tokens that we won't use, and clients may find it
+      -- easier to clean them up if they receive begin/end reports for them.
+      liftIO $ threadDelay startDelay
+      case clientToken of
+        -- See Note [Client- versus server-initiated progress]
+        -- Client-initiated progress
+        Just t -> registerToken t
+        -- Try server-initiated progress
+        Nothing -> do
+          t <- getNewProgressId
+          clientCaps <- getClientCapabilities
+
+          -- If we don't have a progress token from the client and
+          -- the client doesn't support server-initiated progress then
+          -- there's nothing to do: we can't report progress.
+          when (clientSupportsServerInitiatedProgress clientCaps)
+            $ void
+            $
+            -- Server-initiated progress
+            -- See Note [Client- versus server-initiated progress]
+            sendRequest
+              SMethod_WindowWorkDoneProgressCreate
+              (WorkDoneProgressCreateParams t)
+            $ \case
+              -- Successfully registered the token, we can now use it.
+              -- So we go ahead and start. We do this as soon as we get the
+              -- token back so the client gets feedback ASAP
+              Right _ -> registerToken t
+              -- The client sent us an error, we can't use the token.
+              Left _err -> pure ()
+
+    -- Actually send the progress reports.
+    sendReports :: m ()
+    sendReports = do
+      t <- liftIO $ atomically $ readTMVar tokenVar
+      begin t
+      -- Once we are sending updates, if we get interrupted we should send
+      -- the end notification
+      update t `UE.finally` end t
+     where
+      cancellable' = case cancellable of
+        Cancellable -> Just True
+        NotCancellable -> Just False
+      begin t = do
+        (ProgressAmount pct msg) <- liftIO $ atomically $ takeTMVar reportVar
+        sendProgressReport t $ WorkDoneProgressBegin L.AString title cancellable' msg pct
+      update t =
+        forever $ do
+          -- See Note [Delayed progress reporting]
+          liftIO $ threadDelay updateDelay
+          (ProgressAmount pct msg) <- liftIO $ atomically $ takeTMVar reportVar
+          sendProgressReport t $ WorkDoneProgressReport L.AString Nothing msg pct
+      end t = sendProgressReport t (WorkDoneProgressEnd L.AString Nothing)
+
+    -- Create the token and then start sending reports; all of which races with the check for the
+    -- progress having ended. In all cases, make sure to unregister the token at the end.
+    progressThreads :: m ()
+    progressThreads =
+      ((createToken >> sendReports) `UE.finally` unregisterToken) `U.race_` liftIO progressEnded
+
+  withRunInIO $ \runInBase -> do
+    withAsync (runInBase $ f updater) $ \mainAct ->
+      -- If the progress gets cancelled then we need to get cancelled too
+      withAsync (runInBase progressThreads) $ \pthreads -> do
+        r <- waitEither mainAct pthreads
+        -- TODO: is this weird? I can't see how else to gracefully use the ending barrier
+        -- as a guard to cancel the other async
+        case r of
+          Left a -> pure a
+          Right _ -> cancelWith mainAct ProgressCancelledException >> wait mainAct
+ where
+  sendProgressReport :: (J.ToJSON r) => ProgressToken -> r -> m ()
+  sendProgressReport token report = sendNotification SMethod_Progress $ ProgressParams token $ J.toJSON report
+
+  getProgressCancellationHandlers :: m (TVar (Map.Map ProgressToken (IO ())))
+  getProgressCancellationHandlers = getStateVar (progressCancel . resProgressData)
+
+clientSupportsServerInitiatedProgress :: L.ClientCapabilities -> Bool
+clientSupportsServerInitiatedProgress caps = fromMaybe False $ caps ^? L.window . _Just . L.workDoneProgress . _Just
+{-# INLINE clientSupportsServerInitiatedProgress #-}
+
+{- |
+Wrapper for reporting progress to the client during a long running task.
+-}
+withProgress ::
+  MonadLsp c m =>
+  -- | The title of the progress operation
+  Text ->
+  -- | The progress token provided by the client in the method params, if any
+  Maybe ProgressToken ->
+  -- | Whether or not this operation is cancellable. If true, the user will be
+  -- shown a button to allow cancellation. Note that requests can still be cancelled
+  -- even if this is not set.
+  ProgressCancellable ->
+  -- | An update function to pass progress updates to
+  ((ProgressAmount -> m ()) -> m a) ->
+  m a
+withProgress title clientToken cancellable f = withProgressBase False title clientToken cancellable f
+
+{- |
+Same as 'withProgress', but for processes that do not report the precentage complete.
+-}
+withIndefiniteProgress ::
+  MonadLsp c m =>
+  -- | The title of the progress operation
+  Text ->
+  -- | The progress token provided by the client in the method params, if any
+  Maybe ProgressToken ->
+  -- | Whether or not this operation is cancellable. If true, the user will be
+  -- shown a button to allow cancellation. Note that requests can still be cancelled
+  -- even if this is not set.
+  ProgressCancellable ->
+  -- | An update function to pass progress updates to
+  ((Text -> m ()) -> m a) ->
+  m a
+withIndefiniteProgress title clientToken cancellable f =
+  withProgressBase True title clientToken cancellable (\update -> f (\msg -> update (ProgressAmount Nothing (Just msg))))


### PR DESCRIPTION
This had to be redone in order to allow us to "wake up" and notice that there are pending messages. I also wrote it so there can be a stateful interface (the `ProgressTracker`) which I think might make it easier to use in that weird case in `ghcide`. I haven't exposed that yet, though.