### PR TITLE
add inlay hints lsp-test support

### DIFF
--- a/lsp-test/test/DummyServer.hs
+++ b/lsp-test/test/DummyServer.hs
@@ -273,9 +273,9 @@ handlers =
         resp $ Right $ InL [ih]
     , requestHandler SMethod_InlayHintResolve $ \req resp -> do
         let TRequestMessage _ _ _ params = req
-            (InlayHint {_data_= Just data_, ..}) = params
+            (InlayHint{_data_ = Just data_, ..}) = params
             start :: Position
             Success start = fromJSON data_
-            ih = InlayHint {_data_ = Nothing, _tooltip = Just $ InL $ "start at " <> T.pack (show start),  ..}
+            ih = InlayHint{_data_ = Nothing, _tooltip = Just $ InL $ "start at " <> T.pack (show start), ..}
         resp $ Right ih
     ]

--- a/lsp-test/test/DummyServer.hs
+++ b/lsp-test/test/DummyServer.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module DummyServer where
 
@@ -256,4 +257,25 @@ handlers =
         case tokens of
           Left t -> resp $ Left $ ResponseError (InR ErrorCodes_InternalError) t Nothing
           Right tokens -> resp $ Right $ InL tokens
+    , requestHandler SMethod_TextDocumentInlayHint $ \req resp -> do
+        let TRequestMessage _ _ _ params = req
+            InlayHintParams _ _ (Range start end) = params
+            ih =
+              InlayHint
+                end
+                (InL ":: Text")
+                Nothing
+                Nothing
+                Nothing
+                Nothing
+                Nothing
+                (Just $ toJSON start)
+        resp $ Right $ InL [ih]
+    , requestHandler SMethod_InlayHintResolve $ \req resp -> do
+        let TRequestMessage _ _ _ params = req
+            (InlayHint {_data_= Just data_, ..}) = params
+            start :: Position
+            Success start = fromJSON data_
+            ih = InlayHint {_data_ = Nothing, _tooltip = Just $ InL $ "start at " <> T.pack (show start),  ..}
+        resp $ Right ih
     ]

--- a/lsp-test/test/Test.hs
+++ b/lsp-test/test/Test.hs
@@ -454,3 +454,13 @@ main = hspec $ around withDummyServer $ do
       let doc = TextDocumentIdentifier (Uri "")
       InL toks <- getSemanticTokens doc
       liftIO $ toks ^. L.data_ `shouldBe` [0, 1, 2, 1, 0]
+
+  describe "inlay hints" $ do
+    it "get works" $ \(hin, hout) -> runSessionWithHandles hin hout def fullCaps "." $ do
+      doc <- openDoc "test/data/renamePass/Desktop/simple.hs" "haskell"
+      inlayHints <- getInlayHints doc (Range (Position 1 2) (Position 3 4))
+      liftIO $ head inlayHints ^. L.label `shouldBe` InL ":: Text"
+    it "resolve tooltip works" $ \(hin, hout) -> runSessionWithHandles hin hout def fullCaps "." $ do
+      doc <- openDoc "test/data/renamePass/Desktop/simple.hs" "haskell"
+      inlayHints <- getAndResolveInlayHints doc (Range (Position 1 2) (Position 3 4))
+      liftIO $ head inlayHints ^. L.tooltip `shouldBe` Just (InL $ "start at " <> T.pack (show (Position 1 2)))


### PR DESCRIPTION
new:
- `getInlayHints`
- `getAndResolveInlayHints`
- `resolveInlayHint` (helper)