### PR TITLE
Remove dependency on uuid

### DIFF
--- a/lsp/lsp.cabal
+++ b/lsp/lsp.cabal
@@ -80,7 +80,6 @@ library
     , unliftio              ^>=0.2
     , unliftio-core         ^>=0.2
     , unordered-containers  ^>=0.2
-    , uuid                  >=1.3
 
 executable lsp-demo-reactor-server
   import:             warnings

--- a/lsp/src/Language/LSP/Server/Core.hs
+++ b/lsp/src/Language/LSP/Server/Core.hs
@@ -48,7 +48,6 @@ import Data.Monoid (Ap (..))
 import Data.Ord (Down (Down))
 import Data.Text (Text)
 import Data.Text qualified as T
-import Data.UUID qualified as UUID
 import Language.LSP.Diagnostics
 import Language.LSP.Protocol.Capabilities
 import Language.LSP.Protocol.Lens qualified as L
@@ -590,7 +589,7 @@ trySendRegistration logger method regOpts = do
   -- First, check to see if the client supports dynamic registration on this method
   if dynamicRegistrationSupported method clientCaps
     then do
-      uuid <- liftIO $ UUID.toText <$> getStdRandom random
+      uuid <- liftIO $ T.pack <$> sequence (replicate 32 (getStdRandom (randomR (' ', '~'))))
       let registration = L.TRegistration uuid method (Just regOpts)
           params = L.RegistrationParams [toUntypedRegistration registration]
           regId = RegistrationId uuid


### PR DESCRIPTION
While the language server specification uses a UUID for dynamic registration of capabilities, it only has to be a unique id. This change removes the UUID dependency, replacing it with a home-grown random id generator.

The main motivation here is I'm trying to compile LSP (or rather, a program using it) to WASM. The UUID library pulls in a lot of superfluous dependencies (e.g. network-info and entropy) that don't compile with the wasm32-wasm version of GHC, hence trying to remove them.