### PR TITLE
Use our normal auto-incrementing ids instead of UUIDs

### DIFF
--- a/lsp/lsp.cabal
+++ b/lsp/lsp.cabal
@@ -71,7 +71,6 @@ library
     , lsp-types             ^>=2.2
     , mtl                   >=2.2    && <2.4
     , prettyprinter         ^>=1.7
-    , random                ^>=1.2
     , sorted-list           ^>=0.2.1
     , stm                   ^>=2.5
     , text                  >=1      && <2.2

--- a/lsp/lsp.cabal
+++ b/lsp/lsp.cabal
@@ -80,7 +80,6 @@ library
     , unliftio              ^>=0.2
     , unliftio-core         ^>=0.2
     , unordered-containers  ^>=0.2
-    , uuid                  >=1.3
 
 executable lsp-demo-reactor-server
   import:             warnings

--- a/lsp/src/Language/LSP/Server/Core.hs
+++ b/lsp/src/Language/LSP/Server/Core.hs
@@ -48,7 +48,6 @@ import Data.Monoid (Ap (..))
 import Data.Ord (Down (Down))
 import Data.Text (Text)
 import Data.Text qualified as T
-import Data.UUID qualified as UUID
 import Language.LSP.Diagnostics
 import Language.LSP.Protocol.Capabilities
 import Language.LSP.Protocol.Lens qualified as L
@@ -61,7 +60,6 @@ import Language.LSP.Protocol.Utils.SMethodMap (SMethodMap)
 import Language.LSP.Protocol.Utils.SMethodMap qualified as SMethodMap
 import Language.LSP.VFS hiding (end)
 import Prettyprinter
-import System.Random hiding (next)
 
 -- ---------------------------------------------------------------------
 {-# ANN module ("HLint: ignore Eta reduce" :: String) #-}
@@ -590,10 +588,10 @@ trySendRegistration logger method regOpts = do
   -- First, check to see if the client supports dynamic registration on this method
   if dynamicRegistrationSupported method clientCaps
     then do
-      uuid <- liftIO $ UUID.toText <$> getStdRandom random
-      let registration = L.TRegistration uuid method (Just regOpts)
+      rid <- T.pack . show <$> freshLspId
+      let registration = L.TRegistration rid method (Just regOpts)
           params = L.RegistrationParams [toUntypedRegistration registration]
-          regId = RegistrationId uuid
+          regId = RegistrationId rid
 
       -- TODO: handle the scenario where this returns an error
       _ <- sendRequest SMethod_ClientRegisterCapability params $ \_res -> pure ()


### PR DESCRIPTION
The spec just says they have to be unique IDs, not UUIDs, and we already have a tool for generating such things.