### PR TITLE
Expose resolveCompletion helper in lsp-test

### DIFF
--- a/lsp-test/src/Language/LSP/Test.hs
+++ b/lsp-test/src/Language/LSP/Test.hs
@@ -93,6 +93,7 @@ module Language.LSP.Test (
   -- ** Completions
   getCompletions,
   getAndResolveCompletions,
+  resolveCompletion,
 
   -- ** References
   getReferences,


### PR DESCRIPTION
Helpful for defining tests where we call `getCompletion` and `resolveCompletion` separately.