### PR TITLE
chore: export emptyNormalizedUri

### DIFF
--- a/lsp-types/ChangeLog.md
+++ b/lsp-types/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for lsp-types
 
+## Unreleased 
+
+- export `emptyNormalizedUri` from `Language.LSP.Protocol.Types.Uri`
+
 ## 2.3.0.1 -- 2024-12-31
 
 - Relax dependency version bounds

--- a/lsp-types/src/Language/LSP/Protocol/Types/Uri.hs
+++ b/lsp-types/src/Language/LSP/Protocol/Types/Uri.hs
@@ -14,6 +14,7 @@ module Language.LSP.Protocol.Types.Uri (
   normalizedFilePathToUri,
   uriToNormalizedFilePath,
   emptyNormalizedFilePath,
+  emptyNormalizedUri,
   -- Private functions
   platformAwareUriToFilePath,
   platformAwareFilePathToUri,


### PR DESCRIPTION
- I was missing this function and it is redefined in haskell-language-server. Maybe a nice chance to lose a duplication :) 