### PR TITLE
Gracefullyexit

### DIFF
--- a/lsp/src/Language/LSP/Server/Control.hs
+++ b/lsp/src/Language/LSP/Server/Control.hs
@@ -158,9 +158,7 @@ runServerWith ioLogger logger clientIn clientOut serverDefinition = do
     r <- race (wait _sendAsync) (threadDelay 3_000_000)
     case r of
       Left _  -> pure ()
-      Right _ -> do
-        ioLogger <& SenderShutdownTimeout `WithSeverity` Warning
-        cancel _sendAsync
+      Right _ -> ioLogger <& SenderShutdownTimeout `WithSeverity` Warning
     ioLogger <& ServerStopped `WithSeverity` Info
     return res
 

--- a/lsp/src/Language/LSP/Server/Control.hs
+++ b/lsp/src/Language/LSP/Server/Control.hs
@@ -149,9 +149,9 @@ runServerWith ioLogger logger clientIn clientOut serverDefinition = do
   cout <- atomically newTChan :: IO (TChan FromServerMessage)
   withAsync (sendServer ioLogger cout clientOut) $ \_sendAsync -> do
     let sendMsg = atomically . writeTChan cout
-    ioLoop ioLogger logger clientIn serverDefinition emptyVFS sendMsg
+    res <- ioLoop ioLogger logger clientIn serverDefinition emptyVFS sendMsg
     ioLogger <& ServerStopped `WithSeverity` Info
-    return 0
+    return res
 
 -- ---------------------------------------------------------------------
 
@@ -163,33 +163,37 @@ ioLoop ::
   ServerDefinition config ->
   VFS ->
   (FromServerMessage -> IO ()) ->
-  IO ()
+  IO Int
 ioLoop ioLogger logger clientIn serverDefinition vfs sendMsg = do
   minitialize <- parseOne ioLogger clientIn (parse parser "")
   case minitialize of
-    Nothing -> pure ()
+    Nothing -> pure 1
     Just (msg, remainder) -> do
       case J.eitherDecode $ BSL.fromStrict msg of
-        Left err -> ioLogger <& DecodeInitializeError err `WithSeverity` Error
+        Left err -> do
+          ioLogger <& DecodeInitializeError err `WithSeverity` Error
+          return 1
         Right initialize -> do
           mInitResp <- Processing.initializeRequestHandler pioLogger serverDefinition vfs sendMsg initialize
           case mInitResp of
-            Nothing -> pure ()
+            Nothing -> pure 1
             Just env -> runLspT env $ loop (parse parser remainder)
  where
   pioLogger = L.cmap (fmap LspProcessingLog) ioLogger
   pLogger = L.cmap (fmap LspProcessingLog) logger
 
-  loop :: Result BS.ByteString -> LspM config ()
+  loop :: Result BS.ByteString -> LspM config Int
   loop = go
    where
     go r = do
-      res <- parseOne logger clientIn r
-      case res of
-        Nothing -> pure ()
-        Just (msg, remainder) -> do
-          Processing.processMessage pLogger $ BSL.fromStrict msg
-          go (parse parser remainder)
+      b <- isExiting
+      if b then pure 0 else do
+        res <- parseOne logger clientIn r
+        case res of
+          Nothing -> pure 1
+          Just (msg, remainder) -> do
+            Processing.processMessage pLogger $ BSL.fromStrict msg
+            go (parse parser remainder)
 
   parser = do
     try contentType <|> return ()

--- a/lsp/src/Language/LSP/Server/Control.hs
+++ b/lsp/src/Language/LSP/Server/Control.hs
@@ -12,7 +12,8 @@ module Language.LSP.Server.Control (
 import Colog.Core (LogAction (..), Severity (..), WithSeverity (..), (<&))
 import Colog.Core qualified as L
 import Control.Applicative ((<|>))
-import Control.Concurrent.Async (withAsync)
+import Control.Concurrent.Async (withAsync, wait, cancel, race)
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.STM.TChan
 import Control.Exception (catchJust, throwIO)
 import Control.Monad.IO.Class
@@ -44,6 +45,7 @@ data LspServerLog
   | BrokenPipeWhileSending TL.Text -- truncated outgoing message (including header)
   | Starting
   | ServerStopped
+  | SenderShutdownTimeout -- client sender did not stop in time
   | ParsedMsg T.Text
   | SendMsg TL.Text
   deriving (Show)
@@ -70,6 +72,7 @@ instance Pretty LspServerLog where
   pretty Starting = "Server starting"
   pretty (ParsedMsg msg) = "---> " <> pretty msg
   pretty (SendMsg msg) = "<--2-- " <> pretty msg
+  pretty SenderShutdownTimeout = "Sender did not stop within 3s; cancelling"
 
 -- ---------------------------------------------------------------------
 
@@ -150,6 +153,14 @@ runServerWith ioLogger logger clientIn clientOut serverDefinition = do
   withAsync (sendServer ioLogger cout clientOut) $ \_sendAsync -> do
     let sendMsg = atomically . writeTChan cout
     res <- ioLoop ioLogger logger clientIn serverDefinition emptyVFS sendMsg
+    -- The sender should stop after we send the shutdown response.
+    -- Wait up to 3 seconds for the sender to finish; cancel if it doesn't.
+    r <- race (wait _sendAsync) (threadDelay 3_000_000)
+    case r of
+      Left _  -> pure ()
+      Right _ -> do
+        ioLogger <& SenderShutdownTimeout `WithSeverity` Warning
+        cancel _sendAsync
     ioLogger <& ServerStopped `WithSeverity` Info
     return res
 

--- a/lsp/src/Language/LSP/Server/Control.hs
+++ b/lsp/src/Language/LSP/Server/Control.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Language.LSP.Server.Control (
   -- * Running
@@ -11,9 +12,9 @@ module Language.LSP.Server.Control (
 import Colog.Core (LogAction (..), Severity (..), WithSeverity (..), (<&))
 import Colog.Core qualified as L
 import Control.Applicative ((<|>))
-import Control.Concurrent
+import Control.Concurrent.Async (withAsync)
 import Control.Concurrent.STM.TChan
-import Control.Monad
+import Control.Exception (catchJust, throwIO)
 import Control.Monad.IO.Class
 import Control.Monad.STM
 import Data.Aeson qualified as J
@@ -33,18 +34,22 @@ import Language.LSP.Server.Processing qualified as Processing
 import Language.LSP.VFS
 import Prettyprinter
 import System.IO
+import System.IO.Error (isResourceVanishedError)
 
 data LspServerLog
   = LspProcessingLog Processing.LspProcessingLog
   | DecodeInitializeError String
   | HeaderParseFail [String] String
   | EOF
+  | BrokenPipeWhileSending TL.Text -- truncated outgoing message (including header)
   | Starting
+  | ServerStopped
   | ParsedMsg T.Text
   | SendMsg TL.Text
   deriving (Show)
 
 instance Pretty LspServerLog where
+  pretty ServerStopped = "Server stopped"
   pretty (LspProcessingLog l) = pretty l
   pretty (DecodeInitializeError err) =
     vsep
@@ -57,7 +62,12 @@ instance Pretty LspServerLog where
       , pretty (intercalate " > " ctxs) <> ": " <+> pretty err
       ]
   pretty EOF = "Got EOF"
-  pretty Starting = "Starting server"
+  pretty (BrokenPipeWhileSending msg) =
+    vsep
+      [ "Broken pipe while sending (client likely closed output handle):"
+      , indent 2 (pretty msg)
+      ]
+  pretty Starting = "Server starting"
   pretty (ParsedMsg msg) = "---> " <> pretty msg
   pretty (SendMsg msg) = "<--2-- " <> pretty msg
 
@@ -108,9 +118,15 @@ runServerWithHandles ioLogger logger hin hout serverDefinition = do
   let
     clientIn = BS.hGetSome hin defaultChunkSize
 
-    clientOut out = do
-      BSL.hPut hout out
-      hFlush hout
+    clientOut out =
+      catchJust
+        (\e -> if isResourceVanishedError e then Just e else Nothing)
+        (BSL.hPut hout out >> hFlush hout)
+        ( \e -> do
+            let txt = TL.toStrict $ TL.take 400 $ TL.decodeUtf8 out -- limit size
+            ioLogger <& BrokenPipeWhileSending (TL.fromStrict txt) `WithSeverity` Error
+            throwIO e
+        )
 
   runServerWith ioLogger logger clientIn clientOut serverDefinition
 
@@ -130,15 +146,12 @@ runServerWith ::
   IO Int -- exit code
 runServerWith ioLogger logger clientIn clientOut serverDefinition = do
   ioLogger <& Starting `WithSeverity` Info
-
-  cout <- atomically newTChan :: IO (TChan J.Value)
-  _rhpid <- forkIO $ sendServer ioLogger cout clientOut
-
-  let sendMsg msg = atomically $ writeTChan cout $ J.toJSON msg
-
-  ioLoop ioLogger logger clientIn serverDefinition emptyVFS sendMsg
-
-  return 1
+  cout <- atomically newTChan :: IO (TChan FromServerMessage)
+  withAsync (sendServer ioLogger cout clientOut) $ \_sendAsync -> do
+    let sendMsg = atomically . writeTChan cout
+    ioLoop ioLogger logger clientIn serverDefinition emptyVFS sendMsg
+    ioLogger <& ServerStopped `WithSeverity` Info
+    return 0
 
 -- ---------------------------------------------------------------------
 
@@ -224,9 +237,10 @@ parseOne logger clientIn = go
 -- ---------------------------------------------------------------------
 
 -- | Simple server to make sure all output is serialised
-sendServer :: LogAction IO (WithSeverity LspServerLog) -> TChan J.Value -> (BSL.ByteString -> IO ()) -> IO ()
-sendServer _logger msgChan clientOut = do
-  forever $ do
+sendServer :: LogAction IO (WithSeverity LspServerLog) -> TChan FromServerMessage -> (BSL.ByteString -> IO ()) -> IO ()
+sendServer _logger msgChan clientOut = go
+ where
+  go = do
     msg <- atomically $ readTChan msgChan
 
     -- We need to make sure we only send over the content of the message,
@@ -241,6 +255,10 @@ sendServer _logger msgChan clientOut = do
             ]
 
     clientOut out
+    -- close the client sender when we send out the shutdown request's response
+    case msg of
+      FromServerRsp SMethod_Shutdown _ -> pure ()
+      _ -> go
 
 -- TODO: figure out how to re-enable
 -- This can lead to infinite recursion in logging, see https://github.com/haskell/lsp/issues/447

--- a/lsp/src/Language/LSP/Server/Core.hs
+++ b/lsp/src/Language/LSP/Server/Core.hs
@@ -211,6 +211,7 @@ data LanguageContextState config = LanguageContextState
   , resRegistrationsReq :: !(TVar (RegistrationMap Request))
   , resLspId :: !(TVar Int32)
   , resShutdown :: !(C.Barrier ())
+  , resExit :: !(C.Barrier ())
   -- ^ Has the server received 'shutdown'? Can be used to conveniently trigger e.g. thread termination,
   -- but if you need a cleanup action to terminate before exiting, then you should install a full
   -- 'shutdown' handler
@@ -749,6 +750,14 @@ requestConfigUpdate logger = do
 isShuttingDown :: (m ~ LspM config) => m Bool
 isShuttingDown = do
   b <- resShutdown . resState <$> getLspEnv
+  r <- liftIO $ C.waitBarrierMaybe b
+  pure $ case r of
+    Just _ -> True
+    Nothing -> False
+
+isExiting :: (m ~ LspM config) => m Bool
+isExiting = do
+  b <- resExit . resState <$> getLspEnv
   r <- liftIO $ C.waitBarrierMaybe b
   pure $ case r of
     Just _ -> True

--- a/lsp/src/Language/LSP/Server/Processing.hs
+++ b/lsp/src/Language/LSP/Server/Processing.hs
@@ -172,6 +172,7 @@ initializeRequestHandler logger ServerDefinition{..} vfs sendFunc req = do
       resRegistrationsReq <- newTVarIO mempty
       resLspId <- newTVarIO 0
       resShutdown <- C.newBarrier
+      resExit <- C.newBarrier
       pure LanguageContextState{..}
 
     -- Call the 'duringInitialization' callback to let the server kick stuff up
@@ -440,6 +441,7 @@ handle logger m msg =
     SMethod_WorkspaceDidChangeConfiguration -> handle' logger (Just $ handleDidChangeConfiguration logger) m msg
     -- See Note [LSP configuration]
     SMethod_Initialized -> handle' logger (Just $ \_ -> initialDynamicRegistrations logger >> requestConfigUpdate (cmap (fmap LspCore) logger)) m msg
+    SMethod_Exit -> exitNotificationHandler logger msg
     SMethod_Shutdown -> handle' logger (Just $ \_ -> signalShutdown) m msg
      where
       -- See Note [Shutdown]
@@ -466,18 +468,9 @@ handle' ::
   m ()
 handle' logger mAction m msg = do
   shutdown <- isShuttingDown
-  -- These are the methods that we are allowed to process during shutdown.
-  -- The reason that we do not include 'shutdown' itself here is because
-  -- by the time we get the first 'shutdown' message, isShuttingDown will
-  -- still be false, so we would still be able to process it.
-  -- This ensures we won't process the second 'shutdown' message and only
-  -- process 'exit' during shutdown.
-  let allowedMethod m = case (splitClientMethod m, m) of
-        (IsClientNot, SMethod_Exit) -> True
-        _ -> False
 
   case mAction of
-    Just f | not shutdown || allowedMethod m -> f msg
+    Just f | not shutdown -> f msg
     _ -> pure ()
 
   dynReqHandlers <- getsState resRegistrationsReq
@@ -488,14 +481,12 @@ handle' logger mAction m msg = do
 
   case splitClientMethod m of
     -- See Note [Shutdown]
-    IsClientNot | shutdown, not (allowedMethod m) -> notificationDuringShutdown
+    IsClientNot | shutdown -> notificationDuringShutdown
     IsClientNot -> case pickHandler dynNotHandlers notHandlers of
       Just h -> liftIO $ h msg
-      Nothing
-        | SMethod_Exit <- m -> exitNotificationHandler logger msg
-        | otherwise -> missingNotificationHandler
+      Nothing | otherwise -> missingNotificationHandler
     -- See Note [Shutdown]
-    IsClientReq | shutdown, not (allowedMethod m) -> requestDuringShutdown msg
+    IsClientReq | shutdown -> requestDuringShutdown msg
     IsClientReq -> case pickHandler dynReqHandlers reqHandlers of
       Just h -> liftIO $ h msg (runLspT env . sendResponse msg)
       Nothing
@@ -556,10 +547,11 @@ progressCancelHandler logger (TNotificationMessage _ _ (WorkDoneProgressCancelPa
       logger <& ProgressCancel tid `WithSeverity` Debug
       liftIO cancelAction
 
-exitNotificationHandler :: (MonadIO m) => LogAction m (WithSeverity LspProcessingLog) -> Handler m Method_Exit
+exitNotificationHandler :: (MonadIO m, MonadLsp config0 m) => LogAction m (WithSeverity LspProcessingLog) -> Handler m Method_Exit
 exitNotificationHandler logger _ = do
-  logger <& Exiting `WithSeverity` Info
-  liftIO exitSuccess
+  logger <& ShuttingDown `WithSeverity` Info
+  b <- resExit . resState <$> getLspEnv
+  liftIO $ signalBarrier b ()
 
 -- | Default Shutdown handler
 shutdownRequestHandler :: Handler IO Method_Shutdown


### PR DESCRIPTION
This pull request introduces several improvements to the LSP server's shutdown and exit handling, making the server more robust and better aligned with the LSP specification. The changes ensure that output is properly flushed and errors are logged if the client disconnects unexpectedly, and that the server's sender thread is gracefully shut down. The shutdown and exit logic is now more explicit, with new state tracking and barriers to prevent race conditions.

**Improvements to shutdown and exit handling:**

* Added a new `resExit` barrier to `LanguageContextState` and an `isExiting` function to track when the server should exit, ensuring that the server stops processing messages after an exit notification is received. [[1]](diffhunk://#diff-5bee544b3fab317dbb9e41af9ddded3acb9b0a4a1cb6dca7fbb7b3c903e4dd96R214) [[2]](diffhunk://#diff-5bee544b3fab317dbb9e41af9ddded3acb9b0a4a1cb6dca7fbb7b3c903e4dd96R758-R765)
* Modified the main server loop and sender logic to wait for the sender thread to finish after shutdown, with a timeout and logging if it does not stop in time. Also logs when the server is stopped.
* Improved the implementation of the `exitNotificationHandler` to signal the new exit barrier instead of calling `exitSuccess` directly, allowing for a more coordinated shutdown.
* Simplified the logic in `handle'` to only allow message processing before shutdown, and to block all further messages after shutdown except for the necessary exit notification. [[1]](diffhunk://#diff-7ddecffae1af581bca5ca41258e9f1c668ae8cf3c80f1610cf6f5c34a9004e6eL469-R473) [[2]](diffhunk://#diff-7ddecffae1af581bca5ca41258e9f1c668ae8cf3c80f1610cf6f5c34a9004e6eL491-R489)

**Error handling and logging enhancements:**

* Enhanced `clientOut` to catch and log `BrokenPipe` errors when sending output fails (e.g., if the client closes the output handle), including a truncated version of the outgoing message for debugging.
* Added new log messages and `LspServerLog` variants for broken pipes, server stopping, and sender shutdown timeouts, with corresponding pretty-printing for improved diagnostics. [[1]](diffhunk://#diff-e4eea92a213690294a8e66c2b6ce7a55053989dece1341a03d895f1646e31a59R38-R54) [[2]](diffhunk://#diff-e4eea92a213690294a8e66c2b6ce7a55053989dece1341a03d895f1646e31a59L60-R75)

**Concurrency and threading improvements:**

* Replaced manual thread management with `withAsync` and `race` to better manage the sender thread lifecycle and ensure clean shutdowns. [[1]](diffhunk://#diff-e4eea92a213690294a8e66c2b6ce7a55053989dece1341a03d895f1646e31a59L14-R18) [[2]](diffhunk://#diff-e4eea92a213690294a8e66c2b6ce7a55053989dece1341a03d895f1646e31a59L133-R165)
* Updated the `sendServer` function to terminate after sending the shutdown response, preventing further messages from being sent after shutdown. [[1]](diffhunk://#diff-e4eea92a213690294a8e66c2b6ce7a55053989dece1341a03d895f1646e31a59L227-R258) [[2]](diffhunk://#diff-e4eea92a213690294a8e66c2b6ce7a55053989dece1341a03d895f1646e31a59R273-R276)

These changes improve the LSP server's reliability and make its shutdown and exit behavior more predictable and maintainable.